### PR TITLE
fix startup crash

### DIFF
--- a/WXYC/Base.lproj/Main.storyboard
+++ b/WXYC/Base.lproj/Main.storyboard
@@ -6,6 +6,7 @@
     <dependencies>
         <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
+        <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <customFonts key="customFonts">
@@ -27,35 +28,36 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="uXf-Wr-UiK" userLabel="Background Image View">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="uXf-Wr-UiK" userLabel="Background Image View">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="obn-8m-awZ" userLabel="AlbumArt" customClass="SpringImageView" customModule="WXYC" customModuleProvider="target">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" translatesAutoresizingMaskIntoConstraints="NO" id="obn-8m-awZ" userLabel="AlbumArt" customClass="SpringImageView" customModule="WXYC" customModuleProvider="target">
                                 <rect key="frame" x="70" y="101" width="180" height="180"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="180" id="hCD-tK-vVP"/>
+                                </constraints>
                             </imageView>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Song Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KC8-ZG-rx5" userLabel="Song Label" customClass="SpringLabel" customModule="WXYC" customModuleProvider="target">
-                                <rect key="frame" x="16" y="305" width="288" height="33"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Song Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KC8-ZG-rx5" userLabel="Song Label" customClass="SpringLabel" customModule="WXYC" customModuleProvider="target">
+                                <rect key="frame" x="16" y="442" width="288" height="33"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="24"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="v3l-q6-g0h" userLabel="Artist Label">
-                                <rect key="frame" x="16" y="337" width="288" height="25"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="v3l-q6-g0h" userLabel="Artist Label">
+                                <rect key="frame" x="16" y="474" width="288" height="25"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="JCK-L1-2Sc" userLabel="PlayerControls View">
-                                <rect key="frame" x="91" y="432" width="138" height="70"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JCK-L1-2Sc" userLabel="PlayerControls View">
+                                <rect key="frame" x="91" y="298" width="138" height="70"/>
                                 <subviews>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D3H-co-r2v" userLabel="PlayButton">
+                                    <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D3H-co-r2v" userLabel="PlayButton">
                                         <rect key="frame" x="73" y="20" width="45" height="45"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="45" id="2BM-7x-5Tq"/>
+                                            <constraint firstAttribute="height" constant="45" id="z57-mJ-vRD"/>
+                                        </constraints>
                                         <state key="normal" image="btn-play">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
@@ -63,9 +65,12 @@
                                             <action selector="playPressed" destination="vXZ-lx-hvc" eventType="touchUpInside" id="0gS-uM-VCB"/>
                                         </connections>
                                     </button>
-                                    <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k7t-tN-2wp" userLabel="PauseButton">
+                                    <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="k7t-tN-2wp" userLabel="PauseButton">
                                         <rect key="frame" x="20" y="20" width="45" height="45"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="width" constant="45" id="0QP-4Y-L0R"/>
+                                            <constraint firstAttribute="height" constant="45" id="9ls-Nq-FcF"/>
+                                        </constraints>
                                         <state key="normal" image="btn-pause">
                                             <color key="titleShadowColor" red="0.5" green="0.5" blue="0.5" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                         </state>
@@ -74,10 +79,22 @@
                                         </connections>
                                     </button>
                                 </subviews>
+                                <constraints>
+                                    <constraint firstItem="D3H-co-r2v" firstAttribute="top" secondItem="JCK-L1-2Sc" secondAttribute="top" constant="20" id="9W0-st-1Xl"/>
+                                    <constraint firstItem="D3H-co-r2v" firstAttribute="leading" secondItem="k7t-tN-2wp" secondAttribute="trailing" constant="8" id="CCi-Nw-GJ7"/>
+                                    <constraint firstItem="k7t-tN-2wp" firstAttribute="top" secondItem="JCK-L1-2Sc" secondAttribute="top" constant="20" id="E2f-2h-Xdf"/>
+                                    <constraint firstAttribute="width" constant="138" id="Iau-Ec-PKR"/>
+                                    <constraint firstItem="k7t-tN-2wp" firstAttribute="leading" secondItem="JCK-L1-2Sc" secondAttribute="leading" constant="20" id="R9A-GB-GuH"/>
+                                    <constraint firstAttribute="height" constant="70" id="ZpW-Ox-31t"/>
+                                    <constraint firstAttribute="trailing" secondItem="D3H-co-r2v" secondAttribute="trailing" constant="20" id="nHo-zR-D9H"/>
+                                </constraints>
                             </view>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yfv-H0-2Po" userLabel="InformationButton">
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="infoLight" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Yfv-H0-2Po" userLabel="InformationButton">
                                 <rect key="frame" x="286" y="534" width="22" height="22"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="22" id="IbM-ag-eBx"/>
+                                    <constraint firstAttribute="width" constant="22" id="LtX-vH-4q5"/>
+                                </constraints>
                                 <color key="tintColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <state key="normal">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -87,48 +104,98 @@
                                     <action selector="infoButtonPressed:" destination="vXZ-lx-hvc" eventType="touchUpInside" id="3h6-VM-u2U"/>
                                 </connections>
                             </button>
-                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RA9-OX-Xr1" userLabel="Station Desc Label">
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="RA9-OX-Xr1" userLabel="Station Desc Label">
                                 <rect key="frame" x="70" y="249" width="180" height="21"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="21" id="wJP-em-2hX"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="15"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <view contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="dtX-QN-LoN">
+                            <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="dtX-QN-LoN">
                                 <rect key="frame" x="0.0" y="378" width="320" height="60"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                 <subviews>
-                                    <view alpha="0.5" contentMode="scaleToFill" fixedFrame="YES" translatesAutoresizingMaskIntoConstraints="NO" id="zuj-rb-EKQ" userLabel="Volume View">
+                                    <view alpha="0.5" contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="zuj-rb-EKQ" userLabel="Volume View">
                                         <rect key="frame" x="35" y="10" width="250" height="36"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                         <subviews>
-                                            <slider opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="iFC-eW-7WA">
+                                            <slider opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" value="0.5" minValue="0.0" maxValue="1" translatesAutoresizingMaskIntoConstraints="NO" id="iFC-eW-7WA">
                                                 <rect key="frame" x="-2" y="3" width="254" height="31"/>
-                                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 <connections>
                                                     <action selector="volumeChanged:" destination="vXZ-lx-hvc" eventType="valueChanged" id="ybI-Ho-WvA"/>
                                                 </connections>
                                             </slider>
                                         </subviews>
                                         <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                        <constraints>
+                                            <constraint firstAttribute="bottom" secondItem="iFC-eW-7WA" secondAttribute="bottom" constant="3" id="KJ0-i6-dYU"/>
+                                            <constraint firstItem="iFC-eW-7WA" firstAttribute="top" secondItem="zuj-rb-EKQ" secondAttribute="top" constant="3" id="PM6-85-Xp4"/>
+                                            <constraint firstAttribute="height" constant="36" id="aj1-kW-bYU"/>
+                                            <constraint firstAttribute="trailing" secondItem="iFC-eW-7WA" secondAttribute="trailing" id="prt-vP-IgL"/>
+                                            <constraint firstItem="iFC-eW-7WA" firstAttribute="leading" secondItem="zuj-rb-EKQ" secondAttribute="leading" id="wCJ-gV-vO0"/>
+                                        </constraints>
                                     </view>
-                                    <imageView userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="vol-min" translatesAutoresizingMaskIntoConstraints="NO" id="Kmj-vC-DQe">
+                                    <imageView userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="vol-min" translatesAutoresizingMaskIntoConstraints="NO" id="Kmj-vC-DQe">
                                         <rect key="frame" x="12" y="22" width="18" height="16"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="JV0-PD-1R4"/>
+                                            <constraint firstAttribute="width" constant="18" id="gyX-c6-sFk"/>
+                                        </constraints>
                                     </imageView>
-                                    <imageView userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="vol-max" translatesAutoresizingMaskIntoConstraints="NO" id="Ygz-Co-31f">
+                                    <imageView userInteractionEnabled="NO" contentMode="top" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="vol-max" translatesAutoresizingMaskIntoConstraints="NO" id="Ygz-Co-31f">
                                         <rect key="frame" x="290" y="22" width="18" height="16"/>
-                                        <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                                        <constraints>
+                                            <constraint firstAttribute="height" constant="16" id="CHB-nF-bb4"/>
+                                            <constraint firstAttribute="width" constant="18" id="t9O-wR-FB0"/>
+                                        </constraints>
                                     </imageView>
                                 </subviews>
                                 <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstItem="Kmj-vC-DQe" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="top" constant="22" id="Moz-Sz-poa"/>
+                                    <constraint firstItem="Kmj-vC-DQe" firstAttribute="leading" secondItem="dtX-QN-LoN" secondAttribute="leading" constant="12" id="NfA-Gl-fzP"/>
+                                    <constraint firstItem="zuj-rb-EKQ" firstAttribute="leading" secondItem="Kmj-vC-DQe" secondAttribute="trailing" constant="5" id="Njc-SW-kE8"/>
+                                    <constraint firstAttribute="bottom" secondItem="Kmj-vC-DQe" secondAttribute="bottom" constant="22" id="ben-2h-TyF"/>
+                                    <constraint firstAttribute="trailing" secondItem="Ygz-Co-31f" secondAttribute="trailing" constant="12" id="dmC-lG-w8M"/>
+                                    <constraint firstItem="Ygz-Co-31f" firstAttribute="leading" secondItem="zuj-rb-EKQ" secondAttribute="trailing" constant="5" id="gDO-FM-5jl"/>
+                                    <constraint firstAttribute="bottom" secondItem="Ygz-Co-31f" secondAttribute="bottom" constant="22" id="hXq-xn-pG1"/>
+                                    <constraint firstAttribute="height" constant="60" id="kpK-Rv-wUD"/>
+                                    <constraint firstItem="zuj-rb-EKQ" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="top" constant="10" id="tcn-ph-tTd"/>
+                                    <constraint firstItem="Ygz-Co-31f" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="top" constant="22" id="tyF-Wg-6BH"/>
+                                </constraints>
                             </view>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstAttribute="centerX" secondItem="JCK-L1-2Sc" secondAttribute="centerX" id="1Wd-Ce-ie0"/>
+                            <constraint firstItem="obn-8m-awZ" firstAttribute="leading" secondItem="RA9-OX-Xr1" secondAttribute="leading" id="4LO-kb-G6v"/>
+                            <constraint firstItem="KC8-ZG-rx5" firstAttribute="trailing" secondItem="v3l-q6-g0h" secondAttribute="trailing" id="5SZ-je-i3P"/>
+                            <constraint firstItem="RA9-OX-Xr1" firstAttribute="top" secondItem="obn-8m-awZ" secondAttribute="bottom" constant="-32" id="5fc-ws-2hz"/>
+                            <constraint firstAttribute="trailing" secondItem="Yfv-H0-2Po" secondAttribute="trailing" constant="12" id="6vU-qY-CRF"/>
+                            <constraint firstItem="KC8-ZG-rx5" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="bottom" constant="4" id="82k-u6-ncf"/>
+                            <constraint firstItem="dtX-QN-LoN" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="8aO-tG-Da0"/>
+                            <constraint firstItem="v3l-q6-g0h" firstAttribute="top" secondItem="KC8-ZG-rx5" secondAttribute="bottom" constant="-1" id="9YZ-jv-jn4"/>
+                            <constraint firstItem="obn-8m-awZ" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="37" id="9m0-ca-E91"/>
+                            <constraint firstItem="obn-8m-awZ" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="70" id="Ad0-X2-0Fe"/>
+                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="Yfv-H0-2Po" secondAttribute="bottom" constant="12" id="DQU-jH-gbm"/>
+                            <constraint firstItem="v3l-q6-g0h" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="G7B-ZJ-vHt"/>
+                            <constraint firstItem="JCK-L1-2Sc" firstAttribute="top" secondItem="obn-8m-awZ" secondAttribute="bottom" constant="17" id="OBm-8c-dti"/>
+                            <constraint firstItem="dtX-QN-LoN" firstAttribute="top" secondItem="JCK-L1-2Sc" secondAttribute="bottom" constant="10" id="TD6-Jv-Vkj"/>
+                            <constraint firstItem="v3l-q6-g0h" firstAttribute="trailing" secondItem="kh9-bI-dsS" secondAttribute="trailingMargin" id="fmg-j6-zIe"/>
+                            <constraint firstItem="uXf-Wr-UiK" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="hPm-1B-yKf"/>
+                            <constraint firstItem="KC8-ZG-rx5" firstAttribute="leading" secondItem="v3l-q6-g0h" secondAttribute="leading" id="kPF-QT-yN6"/>
+                            <constraint firstAttribute="trailing" secondItem="dtX-QN-LoN" secondAttribute="trailing" id="kQd-xy-Nl1"/>
+                            <constraint firstAttribute="trailing" secondItem="obn-8m-awZ" secondAttribute="trailing" constant="70" id="mbe-x3-NBX"/>
+                            <constraint firstItem="obn-8m-awZ" firstAttribute="trailing" secondItem="RA9-OX-Xr1" secondAttribute="trailing" id="uX9-xo-4bC"/>
+                            <constraint firstItem="uXf-Wr-UiK" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="ukJ-i6-3WQ"/>
+                            <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="uXf-Wr-UiK" secondAttribute="bottom" id="vqi-Me-nfe"/>
+                            <constraint firstAttribute="trailing" secondItem="uXf-Wr-UiK" secondAttribute="trailing" id="wlz-dV-IhI"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" title="Swift Radio" id="OKR-cw-CyI"/>
                     <nil key="simulatedBottomBarMetrics"/>
                     <connections>
+                        <outlet property="albumHeightConstraint" destination="hCD-tK-vVP" id="VlU-n5-VPe"/>
                         <outlet property="albumImageView" destination="obn-8m-awZ" id="13r-WO-VAs"/>
                         <outlet property="artistLabel" destination="v3l-q6-g0h" id="s0B-6Y-MWu"/>
                         <outlet property="pauseButton" destination="k7t-tN-2wp" id="hY6-Tz-wKV"/>
@@ -182,22 +249,25 @@
                         <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="fdb-DQ-3fT" userLabel="Background Image View">
+                            <imageView userInteractionEnabled="NO" contentMode="scaleToFill" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="background" translatesAutoresizingMaskIntoConstraints="NO" id="fdb-DQ-3fT" userLabel="Background Image View">
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                             </imageView>
-                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" fixedFrame="YES" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-ka-9k5">
-                                <rect key="frame" x="16" y="77" width="288" height="427"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-ka-9k5">
+                                <rect key="frame" x="16" y="269" width="288" height="235"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" relation="lessThanOrEqual" priority="750" constant="340" id="ulU-kP-hZB"/>
+                                </constraints>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</string>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Btu-bZ-7Pz">
-                                <rect key="frame" x="16" y="497" width="288" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Btu-bZ-7Pz">
+                                <rect key="frame" x="16" y="512" width="288" height="36"/>
                                 <color key="backgroundColor" red="0.15054957568645477" green="0.15034264326095581" blue="0.15674735605716705" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="36" id="Gpj-99-oS5"/>
+                                </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
                                 <state key="normal" title="Back to the music">
                                     <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
@@ -206,25 +276,47 @@
                                     <action selector="okayButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="9TB-Rq-c2B"/>
                                 </connections>
                             </button>
-                            <button opaque="NO" contentMode="scaleToFill" fixedFrame="YES" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="x0o-Sv-vdX">
-                                <rect key="frame" x="16" y="438" width="288" height="50"/>
-                                <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
-                                <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
-                                <state key="normal" title="Send us feedback on the app">
-                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
-                                </state>
-                                <connections>
-                                    <action selector="feedbackButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="wNz-mS-76v"/>
-                                </connections>
-                            </button>
+                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stationImage" translatesAutoresizingMaskIntoConstraints="NO" id="AHg-sm-9St">
+                                <rect key="frame" x="38" y="79" width="244" height="182"/>
+                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                                <constraints>
+                                    <constraint firstAttribute="height" constant="182" id="32C-Nf-qzK"/>
+                                    <constraint firstAttribute="width" constant="244" id="p2F-25-jWE"/>
+                                </constraints>
+                            </imageView>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <constraints>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" constant="38" id="39w-VH-wMa"/>
+                            <constraint firstAttribute="trailing" secondItem="fdb-DQ-3fT" secondAttribute="trailing" id="50c-4f-6Rq"/>
+                            <constraint firstItem="cJI-ka-9k5" firstAttribute="top" secondItem="AHg-sm-9St" secondAttribute="bottom" constant="8" id="9Gh-jy-Yy3"/>
+                            <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="fdb-DQ-3fT" secondAttribute="bottom" id="Deu-DP-ZdA"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" constant="38" id="FiS-jK-sP0"/>
+                            <constraint firstItem="cJI-ka-9k5" firstAttribute="trailing" secondItem="s9T-KA-lNI" secondAttribute="trailingMargin" id="Hen-oS-7sZ"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" constant="79" id="HhE-PJ-Pix"/>
+                            <constraint firstItem="Btu-bZ-7Pz" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" id="Hug-Fw-O8g"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="cJI-ka-9k5" secondAttribute="centerX" id="N6H-kl-Uwy"/>
+                            <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="Btu-bZ-7Pz" secondAttribute="bottom" constant="20" id="OPV-8J-b08"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="uln-hJ-iAw" secondAttribute="bottom" constant="15" id="Pq9-YF-69p"/>
+                            <constraint firstAttribute="trailingMargin" secondItem="AHg-sm-9St" secondAttribute="trailing" constant="22" id="Qkz-yo-zK4"/>
+                            <constraint firstItem="fdb-DQ-3fT" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" id="SJ6-JW-zZf"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" constant="22" id="YuN-uv-IOe"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="s9T-KA-lNI" secondAttribute="centerX" id="cR8-Xl-FvE"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="fdb-DQ-3fT" secondAttribute="centerX" id="fBm-gN-lrb"/>
+                            <constraint firstItem="Btu-bZ-7Pz" firstAttribute="top" relation="greaterThanOrEqual" secondItem="cJI-ka-9k5" secondAttribute="bottom" constant="8" id="hUN-VG-lfJ"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="Btu-bZ-7Pz" secondAttribute="centerX" id="lKx-5q-geB"/>
+                            <constraint firstItem="fdb-DQ-3fT" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" id="lWc-j3-nIR"/>
+                            <constraint firstItem="cJI-ka-9k5" firstAttribute="top" secondItem="AHg-sm-9St" secondAttribute="bottom" constant="8" symbolic="YES" id="ncs-CL-DMf"/>
+                            <constraint firstItem="Btu-bZ-7Pz" firstAttribute="trailing" secondItem="s9T-KA-lNI" secondAttribute="trailingMargin" id="pdc-7R-rld"/>
+                            <constraint firstItem="cJI-ka-9k5" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" id="sRg-kF-Iue"/>
+                            <constraint firstAttribute="centerX" secondItem="Btu-bZ-7Pz" secondAttribute="centerX" id="tqf-w0-bfO"/>
+                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" constant="79" id="yvW-um-EqZ"/>
+                        </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="tsR-lP-4XL"/>
                     <connections>
-                        <outlet property="feedbackButton" destination="x0o-Sv-vdX" id="ceP-PY-FrR"/>
                         <outlet property="okayButton" destination="Btu-bZ-7Pz" id="KKq-7u-ccR"/>
+                        <outlet property="stationImageView" destination="AHg-sm-9St" id="1sp-xW-r7e"/>
                         <outlet property="stationLongDescTextView" destination="cJI-ka-9k5" id="jjN-GP-9aO"/>
                     </connections>
                 </viewController>
@@ -237,6 +329,7 @@
         <image name="background" width="320" height="568"/>
         <image name="btn-pause" width="44" height="44"/>
         <image name="btn-play" width="44" height="44"/>
+        <image name="stationImage" width="300" height="200"/>
         <image name="vol-max" width="16" height="14"/>
         <image name="vol-min" width="11" height="12"/>
     </resources>

--- a/WXYC/Base.lproj/Main.storyboard
+++ b/WXYC/Base.lproj/Main.storyboard
@@ -4,7 +4,6 @@
         <adaptation id="fullscreen"/>
     </device>
     <dependencies>
-        <deployment identifier="iOS"/>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13173"/>
         <capability name="Constraints to layout margins" minToolsVersion="6.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -38,19 +37,19 @@
                                 </constraints>
                             </imageView>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Song Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="KC8-ZG-rx5" userLabel="Song Label" customClass="SpringLabel" customModule="WXYC" customModuleProvider="target">
-                                <rect key="frame" x="16" y="442" width="288" height="33"/>
+                                <rect key="frame" x="16" y="307" width="288" height="33"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="24"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Artist Name" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumScaleFactor="0.5" translatesAutoresizingMaskIntoConstraints="NO" id="v3l-q6-g0h" userLabel="Artist Label">
-                                <rect key="frame" x="16" y="474" width="288" height="25"/>
+                                <rect key="frame" x="16" y="339" width="288" height="25"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="18"/>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <nil key="highlightedColor"/>
                             </label>
                             <view contentMode="scaleToFill" translatesAutoresizingMaskIntoConstraints="NO" id="JCK-L1-2Sc" userLabel="PlayerControls View">
-                                <rect key="frame" x="91" y="298" width="138" height="70"/>
+                                <rect key="frame" x="91" y="433" width="138" height="70"/>
                                 <subviews>
                                     <button opaque="NO" contentMode="scaleToFill" enabled="NO" contentHorizontalAlignment="center" contentVerticalAlignment="center" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="D3H-co-r2v" userLabel="PlayButton">
                                         <rect key="frame" x="73" y="20" width="45" height="45"/>
@@ -172,15 +171,15 @@
                             <constraint firstItem="KC8-ZG-rx5" firstAttribute="trailing" secondItem="v3l-q6-g0h" secondAttribute="trailing" id="5SZ-je-i3P"/>
                             <constraint firstItem="RA9-OX-Xr1" firstAttribute="top" secondItem="obn-8m-awZ" secondAttribute="bottom" constant="-32" id="5fc-ws-2hz"/>
                             <constraint firstAttribute="trailing" secondItem="Yfv-H0-2Po" secondAttribute="trailing" constant="12" id="6vU-qY-CRF"/>
-                            <constraint firstItem="KC8-ZG-rx5" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="bottom" constant="4" id="82k-u6-ncf"/>
+                            <constraint firstItem="KC8-ZG-rx5" firstAttribute="top" secondItem="dtX-QN-LoN" secondAttribute="bottom" constant="-131" id="82k-u6-ncf"/>
                             <constraint firstItem="dtX-QN-LoN" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" id="8aO-tG-Da0"/>
                             <constraint firstItem="v3l-q6-g0h" firstAttribute="top" secondItem="KC8-ZG-rx5" secondAttribute="bottom" constant="-1" id="9YZ-jv-jn4"/>
                             <constraint firstItem="obn-8m-awZ" firstAttribute="top" secondItem="jyV-Pf-zRb" secondAttribute="bottom" constant="37" id="9m0-ca-E91"/>
                             <constraint firstItem="obn-8m-awZ" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leading" constant="70" id="Ad0-X2-0Fe"/>
                             <constraint firstItem="2fi-mo-0CV" firstAttribute="top" secondItem="Yfv-H0-2Po" secondAttribute="bottom" constant="12" id="DQU-jH-gbm"/>
                             <constraint firstItem="v3l-q6-g0h" firstAttribute="leading" secondItem="kh9-bI-dsS" secondAttribute="leadingMargin" id="G7B-ZJ-vHt"/>
-                            <constraint firstItem="JCK-L1-2Sc" firstAttribute="top" secondItem="obn-8m-awZ" secondAttribute="bottom" constant="17" id="OBm-8c-dti"/>
-                            <constraint firstItem="dtX-QN-LoN" firstAttribute="top" secondItem="JCK-L1-2Sc" secondAttribute="bottom" constant="10" id="TD6-Jv-Vkj"/>
+                            <constraint firstItem="JCK-L1-2Sc" firstAttribute="top" secondItem="obn-8m-awZ" secondAttribute="bottom" constant="152" id="OBm-8c-dti"/>
+                            <constraint firstItem="dtX-QN-LoN" firstAttribute="top" secondItem="JCK-L1-2Sc" secondAttribute="bottom" constant="-125" id="TD6-Jv-Vkj"/>
                             <constraint firstItem="v3l-q6-g0h" firstAttribute="trailing" secondItem="kh9-bI-dsS" secondAttribute="trailingMargin" id="fmg-j6-zIe"/>
                             <constraint firstItem="uXf-Wr-UiK" firstAttribute="top" secondItem="kh9-bI-dsS" secondAttribute="top" id="hPm-1B-yKf"/>
                             <constraint firstItem="KC8-ZG-rx5" firstAttribute="leading" secondItem="v3l-q6-g0h" secondAttribute="leading" id="kPF-QT-yN6"/>
@@ -253,20 +252,17 @@
                                 <rect key="frame" x="0.0" y="0.0" width="320" height="568"/>
                             </imageView>
                             <textView clipsSubviews="YES" multipleTouchEnabled="YES" userInteractionEnabled="NO" contentMode="scaleToFill" scrollEnabled="NO" editable="NO" translatesAutoresizingMaskIntoConstraints="NO" id="cJI-ka-9k5">
-                                <rect key="frame" x="16" y="269" width="288" height="235"/>
-                                <constraints>
-                                    <constraint firstAttribute="height" relation="lessThanOrEqual" priority="750" constant="340" id="ulU-kP-hZB"/>
-                                </constraints>
+                                <rect key="frame" x="16" y="74" width="288" height="235"/>
                                 <string key="text">Lorem ipsum dolor sit er elit lamet, consectetaur cillium adipisicing pecu, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat. Duis aute irure dolor in reprehenderit in voluptate velit esse cillum dolore eu fugiat nulla pariatur.</string>
                                 <color key="textColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <fontDescription key="fontDescription" name="AvenirNext-Regular" family="Avenir Next" pointSize="16"/>
                                 <textInputTraits key="textInputTraits" autocapitalizationType="sentences"/>
                             </textView>
                             <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Btu-bZ-7Pz">
-                                <rect key="frame" x="16" y="512" width="288" height="36"/>
+                                <rect key="frame" x="16" y="505" width="288" height="50"/>
                                 <color key="backgroundColor" red="0.15054957568645477" green="0.15034264326095581" blue="0.15674735605716705" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="36" id="Gpj-99-oS5"/>
+                                    <constraint firstAttribute="height" constant="50" id="Gpj-99-oS5"/>
                                 </constraints>
                                 <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
                                 <state key="normal" title="Back to the music">
@@ -276,47 +272,45 @@
                                     <action selector="okayButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="9TB-Rq-c2B"/>
                                 </connections>
                             </button>
-                            <imageView userInteractionEnabled="NO" contentMode="scaleAspectFit" horizontalHuggingPriority="251" verticalHuggingPriority="251" image="stationImage" translatesAutoresizingMaskIntoConstraints="NO" id="AHg-sm-9St">
-                                <rect key="frame" x="38" y="79" width="244" height="182"/>
-                                <color key="tintColor" white="0.33333333333333331" alpha="1" colorSpace="calibratedWhite"/>
+                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" reversesTitleShadowWhenHighlighted="YES" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="XA4-Z3-EKm">
+                                <rect key="frame" x="16" y="445" width="288" height="50"/>
+                                <color key="backgroundColor" red="1" green="0.0" blue="0.0" alpha="0.5" colorSpace="calibratedRGB"/>
                                 <constraints>
-                                    <constraint firstAttribute="height" constant="182" id="32C-Nf-qzK"/>
-                                    <constraint firstAttribute="width" constant="244" id="p2F-25-jWE"/>
+                                    <constraint firstAttribute="height" constant="50" id="cyt-sz-CaE"/>
                                 </constraints>
-                            </imageView>
+                                <fontDescription key="fontDescription" name="AvenirNext-Medium" family="Avenir Next" pointSize="16"/>
+                                <state key="normal" title="Send us feedback on the app">
+                                    <color key="titleColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                                </state>
+                                <connections>
+                                    <action selector="feedbackButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="h7d-UV-unD"/>
+                                    <action selector="okayButtonPressed:" destination="bg5-7y-kdG" eventType="touchUpInside" id="vhU-S6-x6H"/>
+                                </connections>
+                            </button>
                         </subviews>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <constraints>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" constant="38" id="39w-VH-wMa"/>
                             <constraint firstAttribute="trailing" secondItem="fdb-DQ-3fT" secondAttribute="trailing" id="50c-4f-6Rq"/>
-                            <constraint firstItem="cJI-ka-9k5" firstAttribute="top" secondItem="AHg-sm-9St" secondAttribute="bottom" constant="8" id="9Gh-jy-Yy3"/>
+                            <constraint firstItem="cJI-ka-9k5" firstAttribute="top" secondItem="uln-hJ-iAw" secondAttribute="bottom" constant="10" id="9Az-Yv-y3C"/>
                             <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="fdb-DQ-3fT" secondAttribute="bottom" id="Deu-DP-ZdA"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" constant="38" id="FiS-jK-sP0"/>
                             <constraint firstItem="cJI-ka-9k5" firstAttribute="trailing" secondItem="s9T-KA-lNI" secondAttribute="trailingMargin" id="Hen-oS-7sZ"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" constant="79" id="HhE-PJ-Pix"/>
                             <constraint firstItem="Btu-bZ-7Pz" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" id="Hug-Fw-O8g"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="cJI-ka-9k5" secondAttribute="centerX" id="N6H-kl-Uwy"/>
-                            <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="Btu-bZ-7Pz" secondAttribute="bottom" constant="20" id="OPV-8J-b08"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="uln-hJ-iAw" secondAttribute="bottom" constant="15" id="Pq9-YF-69p"/>
-                            <constraint firstAttribute="trailingMargin" secondItem="AHg-sm-9St" secondAttribute="trailing" constant="22" id="Qkz-yo-zK4"/>
+                            <constraint firstItem="E91-K7-5sw" firstAttribute="top" secondItem="Btu-bZ-7Pz" secondAttribute="bottom" constant="13" id="OPV-8J-b08"/>
+                            <constraint firstItem="XA4-Z3-EKm" firstAttribute="centerX" secondItem="Btu-bZ-7Pz" secondAttribute="centerX" id="QdR-My-XrQ"/>
                             <constraint firstItem="fdb-DQ-3fT" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" id="SJ6-JW-zZf"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" constant="22" id="YuN-uv-IOe"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="s9T-KA-lNI" secondAttribute="centerX" id="cR8-Xl-FvE"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="fdb-DQ-3fT" secondAttribute="centerX" id="fBm-gN-lrb"/>
-                            <constraint firstItem="Btu-bZ-7Pz" firstAttribute="top" relation="greaterThanOrEqual" secondItem="cJI-ka-9k5" secondAttribute="bottom" constant="8" id="hUN-VG-lfJ"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="centerX" secondItem="Btu-bZ-7Pz" secondAttribute="centerX" id="lKx-5q-geB"/>
+                            <constraint firstItem="XA4-Z3-EKm" firstAttribute="height" secondItem="Btu-bZ-7Pz" secondAttribute="height" id="Zak-cz-gL6"/>
+                            <constraint firstItem="Btu-bZ-7Pz" firstAttribute="top" secondItem="XA4-Z3-EKm" secondAttribute="bottom" constant="10" id="fZT-fj-fyf"/>
                             <constraint firstItem="fdb-DQ-3fT" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leading" id="lWc-j3-nIR"/>
-                            <constraint firstItem="cJI-ka-9k5" firstAttribute="top" secondItem="AHg-sm-9St" secondAttribute="bottom" constant="8" symbolic="YES" id="ncs-CL-DMf"/>
+                            <constraint firstItem="XA4-Z3-EKm" firstAttribute="width" secondItem="Btu-bZ-7Pz" secondAttribute="width" id="lpM-ky-amb"/>
                             <constraint firstItem="Btu-bZ-7Pz" firstAttribute="trailing" secondItem="s9T-KA-lNI" secondAttribute="trailingMargin" id="pdc-7R-rld"/>
                             <constraint firstItem="cJI-ka-9k5" firstAttribute="leading" secondItem="s9T-KA-lNI" secondAttribute="leadingMargin" id="sRg-kF-Iue"/>
                             <constraint firstAttribute="centerX" secondItem="Btu-bZ-7Pz" secondAttribute="centerX" id="tqf-w0-bfO"/>
-                            <constraint firstItem="AHg-sm-9St" firstAttribute="top" secondItem="s9T-KA-lNI" secondAttribute="top" constant="79" id="yvW-um-EqZ"/>
                         </constraints>
                     </view>
                     <navigationItem key="navigationItem" id="tsR-lP-4XL"/>
                     <connections>
+                        <outlet property="feedbackButton" destination="XA4-Z3-EKm" id="TF2-AG-LrU"/>
                         <outlet property="okayButton" destination="Btu-bZ-7Pz" id="KKq-7u-ccR"/>
-                        <outlet property="stationImageView" destination="AHg-sm-9St" id="1sp-xW-r7e"/>
                         <outlet property="stationLongDescTextView" destination="cJI-ka-9k5" id="jjN-GP-9aO"/>
                     </connections>
                 </viewController>
@@ -329,7 +323,6 @@
         <image name="background" width="320" height="568"/>
         <image name="btn-pause" width="44" height="44"/>
         <image name="btn-play" width="44" height="44"/>
-        <image name="stationImage" width="300" height="200"/>
         <image name="vol-max" width="16" height="14"/>
         <image name="vol-min" width="11" height="12"/>
     </resources>

--- a/WXYC/InfoDetailViewController.swift
+++ b/WXYC/InfoDetailViewController.swift
@@ -1,16 +1,16 @@
 import UIKit
-import MessageUI
 
-class InfoDetailViewController: UIViewController, MFMailComposeViewControllerDelegate {
+class InfoDetailViewController: UIViewController {
     
     @IBOutlet weak var stationImageView: UIImageView!
     @IBOutlet weak var stationNameLabel: UILabel!
     @IBOutlet weak var stationDescLabel: UILabel!
     @IBOutlet weak var stationLongDescTextView: UITextView!
     @IBOutlet weak var okayButton: UIButton!
-    @IBOutlet weak var feedbackButton: UIButton!
+    
     var currentStation: RadioStation!
     var downloadTask: URLSessionDownloadTask?
+
     //*****************************************************************
     // MARK: - ViewDidLoad
     //*****************************************************************
@@ -19,7 +19,7 @@ class InfoDetailViewController: UIViewController, MFMailComposeViewControllerDel
         super.viewDidLoad()
         
         setupStationText()
-        //setupStationLogo()
+        setupStationLogo()
     }
 
     deinit {
@@ -75,18 +75,6 @@ class InfoDetailViewController: UIViewController, MFMailComposeViewControllerDel
         stationImageView.applyShadow()
     }
     
-    func configureMailController() -> MFMailComposeViewController {
-        let mailComposerVC = MFMailComposeViewController()
-        mailComposerVC.mailComposeDelegate = self
-        
-        mailComposerVC.setToRecipients(["dvd@wxyc.org"])
-        mailComposerVC.setSubject("Feedback on the WXYC app")
-        return mailComposerVC
-    }
-    
-    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
-        controller.dismiss(animated: true, completion: nil)
-    }
     //*****************************************************************
     // MARK: - IBActions
     //*****************************************************************
@@ -94,13 +82,5 @@ class InfoDetailViewController: UIViewController, MFMailComposeViewControllerDel
     @IBAction func okayButtonPressed(_ sender: UIButton) {
         _ = navigationController?.popViewController(animated: true)
     }
-    @IBAction func feedbackButtonPressed(_ sender: UIButton) {
-        let mailComposeViewController = configureMailController()
-        if MFMailComposeViewController.canSendMail() {
-            self.present(mailComposeViewController, animated: true, completion: nil)
-        } else {
-        }
-    }
-    
     
 }

--- a/WXYC/InfoDetailViewController.swift
+++ b/WXYC/InfoDetailViewController.swift
@@ -1,12 +1,14 @@
 import UIKit
+import MessageUI
 
-class InfoDetailViewController: UIViewController {
+class InfoDetailViewController: UIViewController, MFMailComposeViewControllerDelegate {
     
     @IBOutlet weak var stationImageView: UIImageView!
     @IBOutlet weak var stationNameLabel: UILabel!
     @IBOutlet weak var stationDescLabel: UILabel!
     @IBOutlet weak var stationLongDescTextView: UITextView!
     @IBOutlet weak var okayButton: UIButton!
+    @IBOutlet weak var feedbackButton: UIButton!
     
     var currentStation: RadioStation!
     var downloadTask: URLSessionDownloadTask?
@@ -19,7 +21,7 @@ class InfoDetailViewController: UIViewController {
         super.viewDidLoad()
         
         setupStationText()
-        setupStationLogo()
+        //setupStationLogo()
     }
 
     deinit {
@@ -27,6 +29,17 @@ class InfoDetailViewController: UIViewController {
         downloadTask?.cancel()
         downloadTask = nil
     }
+    
+    func configureMailController() -> MFMailComposeViewController {
+        let mailComposerVC = MFMailComposeViewController()
+        mailComposerVC.mailComposeDelegate = self
+        mailComposerVC.setToRecipients(["dvd@wxyc.org"])
+        mailComposerVC.setSubject("Feedback on the WXYC app")
+        return mailComposerVC
+        }
+    func mailComposeController(_ controller: MFMailComposeViewController, didFinishWith result: MFMailComposeResult, error: Error?) {
+        controller.dismiss(animated: true, completion: nil)
+        }
     
     //*****************************************************************
     // MARK: - UI Helpers
@@ -82,5 +95,13 @@ class InfoDetailViewController: UIViewController {
     @IBAction func okayButtonPressed(_ sender: UIButton) {
         _ = navigationController?.popViewController(animated: true)
     }
+    @IBAction func feedbackButtonPressed(_ sender: UIButton) {
+        let mailComposeViewController = configureMailController()
+        if MFMailComposeViewController.canSendMail() {
+            self.present(mailComposeViewController, animated: true, completion: nil)
+            } else {
+            }
+    }
+    
     
 }


### PR DESCRIPTION
An earlier commit with UI changes deleted all of the constraints in the view. There's a function that checks one of these constraints on init of the first view, which was getting toasted. Reverted and re-implemented UI changes in a way that preservers the layout constraints. 