### PR TITLE
Fixing a sizing bug in the today widget

### DIFF
--- a/Today Widget/TodayViewController.swift
+++ b/Today Widget/TodayViewController.swift
@@ -64,6 +64,12 @@ class TodayViewController: UIViewController {
             }, completion: nil)
         }
     }
+    
+    override func touchesEnded(_ touches: Set<UITouch>, with event: UIEvent?) {
+        // If the user taps on the today widget, open the app.
+        let url = URL(string: "wxyc://")!
+        self.extensionContext?.open(url, completionHandler: nil)
+    }
 }
 
 extension TodayViewController: NCWidgetProviding {

--- a/Today Widget/TodayViewController.swift
+++ b/Today Widget/TodayViewController.swift
@@ -9,7 +9,7 @@
 import UIKit
 import NotificationCenter
 
-class TodayViewController: UIViewController, NCWidgetProviding {
+class TodayViewController: UIViewController {
     @IBOutlet weak var songLabel: UILabel!
     @IBOutlet weak var artistLabel: UILabel!
     @IBOutlet weak var albumArtworkImageView: UIImageView!
@@ -40,7 +40,9 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         imageRequest.observe(with: self.updateWith(artworkResult:))
     }
     
-    func updateWith(playcutResult result: Result<Playcut>) {
+    // MARK: Webservice request handlers
+    
+    private func updateWith(playcutResult result: Result<Playcut>) {
         guard case let .success(playcut) = result else {
             return
         }
@@ -51,7 +53,7 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         }
     }
     
-    func updateWith(artworkResult: Result<UIImage>) {
+    private func updateWith(artworkResult: Result<UIImage>) {
         DispatchQueue.main.async {
             UIView.transition(with: self.view, duration: 0.25, options: [.transitionCrossDissolve], animations: {
                 if case let .success(artwork) = artworkResult {
@@ -62,19 +64,21 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             }, completion: nil)
         }
     }
-    
+}
+
+extension TodayViewController: NCWidgetProviding {
     func widgetPerformUpdate(completionHandler: (@escaping (NCUpdateResult) -> Void)) {
         completionHandler(NCUpdateResult.newData)
     }
-
+    
     func widgetActiveDisplayModeDidChange(_ activeDisplayMode: NCWidgetDisplayMode, withMaximumSize maxSize: CGSize) {
         self.containerStackView.axis = self.containerAxis(forDisplayMode: activeDisplayMode)
         self.labelsStackView.alignment = self.labelAlignment(forDisplayMode: activeDisplayMode)
-
+        
         self.preferredContentSize = self.view.systemLayoutSizeFitting(UILayoutFittingCompressedSize, withHorizontalFittingPriority: .defaultHigh, verticalFittingPriority: .fittingSizeLevel)
     }
-
-    func containerAxis(forDisplayMode displayMode: NCWidgetDisplayMode) -> UILayoutConstraintAxis {
+    
+    private func containerAxis(forDisplayMode displayMode: NCWidgetDisplayMode) -> UILayoutConstraintAxis {
         switch displayMode {
         case .compact:
             return .horizontal
@@ -82,8 +86,8 @@ class TodayViewController: UIViewController, NCWidgetProviding {
             return .vertical
         }
     }
-
-    func labelAlignment(forDisplayMode displayMode: NCWidgetDisplayMode) -> UIStackViewAlignment {
+    
+    private func labelAlignment(forDisplayMode displayMode: NCWidgetDisplayMode) -> UIStackViewAlignment {
         switch displayMode {
         case .compact:
             return .leading

--- a/Today Widget/TodayViewController.swift
+++ b/Today Widget/TodayViewController.swift
@@ -23,7 +23,10 @@ class TodayViewController: UIViewController, NCWidgetProviding {
         super.viewDidLoad()
 
         if let context = self.extensionContext {
-            context.widgetLargestAvailableDisplayMode = .expanded
+            // TODO: 🐛🔨. I'm commenting this out for now because there's a sizing issue in the expanded mode.
+            // We consistently report a height too high for our content. I played around with some layout code, but
+            // never got to the bottom of this. Anyway, the widget is a bit ungainly in the expanded layout.
+            // context.widgetLargestAvailableDisplayMode = .expanded
 
             self.containerStackView.axis = self.containerAxis(forDisplayMode: context.widgetActiveDisplayMode)
             self.labelsStackView.alignment = self.labelAlignment(forDisplayMode: context.widgetActiveDisplayMode)

--- a/WXYC.xcodeproj/project.pbxproj
+++ b/WXYC.xcodeproj/project.pbxproj
@@ -14,7 +14,6 @@
 		231E5BEC1FCBD5ED00894F18 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 231E5BEA1FCBD5ED00894F18 /* MainInterface.storyboard */; };
 		231E5BF01FCBD5ED00894F18 /* Today Widget.appex in Embed App Extensions */ = {isa = PBXBuildFile; fileRef = 231E5BE31FCBD5EC00894F18 /* Today Widget.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		231E5BF51FCBD7A100894F18 /* RadioStation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94AC70AD1AD05C6200652982 /* RadioStation.swift */; };
-		231E5BF61FCBD7A100894F18 /* Track.swift in Sources */ = {isa = PBXBuildFile; fileRef = 94D260971B45E8B800DE671C /* Track.swift */; };
 		231E5BF71FCBD7A100894F18 /* LastFM.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235101FE1FB93B4500ED3DDF /* LastFM.swift */; };
 		231E5BF81FCBD7A100894F18 /* WXYC.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235102001FB95A1300ED3DDF /* WXYC.swift */; };
 		231E5BF91FCBD7A100894F18 /* iTunes.swift in Sources */ = {isa = PBXBuildFile; fileRef = 235102021FB95B8800ED3DDF /* iTunes.swift */; };
@@ -430,7 +429,6 @@
 				231E5BF51FCBD7A100894F18 /* RadioStation.swift in Sources */,
 				231E5BE91FCBD5ED00894F18 /* TodayViewController.swift in Sources */,
 				231E5BF71FCBD7A100894F18 /* LastFM.swift in Sources */,
-				231E5BF61FCBD7A100894F18 /* Track.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/WXYC/Info.plist
+++ b/WXYC/Info.plist
@@ -20,6 +20,19 @@
 	<string>2.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>org.wxyc.ios</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>wxyc</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>006</string>
 	<key>LSRequiresIPhoneOS</key>

--- a/WXYC/UIView+WXYC.swift
+++ b/WXYC/UIView+WXYC.swift
@@ -29,6 +29,14 @@ extension UIView {
 
 extension UIImage {
     static var defaultNowPlayingInfoCenterImage: UIImage {
+        if DispatchQueue.main == OperationQueue.current?.underlyingQueue {
+            return makeImage()
+        } else {
+            return DispatchQueue.main.sync(execute: makeImage)
+        }
+    }
+    
+    private static func makeImage() -> UIImage {
         let backgroundView = UIImageView(image: #imageLiteral(resourceName: "background"))
         let logoView = UIImageView(image: #imageLiteral(resourceName: "logo"))
         logoView.contentMode = .scaleAspectFit


### PR DESCRIPTION
This PR does more than what it says on the tin. 

First, it disabled the "show more" affordance in the today widget. The widget no longer resizes, and instead stays in compact mode. I did this because I was running into sizing issues in the expanded mode. Initially the height would always be to high, but then it would be fine if you toggled a couple of times. I tried playing around with this, but couldn't fix it. Besides, the expanded mode doesn't look as good.

Second, it factors some of the code in the today widget to be better organized, grouping like functions into extensions and marking them as private where applicable.

Third, I introduce an affordance to launch the app when a user taps on the today widget.