### PR TITLE
Add widget relevance hints for Smart Stack and Spotlight

### DIFF
--- a/Shared/AppServices/Package.swift
+++ b/Shared/AppServices/Package.swift
@@ -31,7 +31,13 @@ let package = Package(
         ),
         .testTarget(
             name: "AppServicesTests",
-            dependencies: ["AppServices", "Caching", "Playlist", "Artwork"]
+            dependencies: [
+                "AppServices",
+                "Caching",
+                "Playlist",
+                "Artwork",
+                .product(name: "PlaybackCore", package: "Playback"),
+            ]
         )
     ]
 )

--- a/Shared/AppServices/Sources/AppServices/NowPlayingWidgetIntent.swift
+++ b/Shared/AppServices/Sources/AppServices/NowPlayingWidgetIntent.swift
@@ -1,0 +1,24 @@
+//
+//  NowPlayingWidgetIntent.swift
+//  AppServices
+//
+//  A minimal WidgetConfigurationIntent for the NowPlayingWidget. Has no
+//  user-configurable parameters; exists solely to enable AppIntentConfiguration
+//  and RelevantIntentManager for Smart Stack relevance hints.
+//
+//  Created by Claude on 02/19/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+#if canImport(WidgetKit)
+import AppIntents
+import WidgetKit
+
+public struct NowPlayingWidgetIntent: WidgetConfigurationIntent {
+    public static let title: LocalizedStringResource = "Now Playing"
+    public static let description: IntentDescription = "Shows what's currently playing on WXYC."
+    public static let isDiscoverable = false
+
+    public init() {}
+}
+#endif

--- a/Shared/AppServices/Sources/AppServices/WidgetRelevanceUpdating.swift
+++ b/Shared/AppServices/Sources/AppServices/WidgetRelevanceUpdating.swift
@@ -1,0 +1,39 @@
+//
+//  WidgetRelevanceUpdating.swift
+//  AppServices
+//
+//  Protocol abstracting RelevantIntentManager for testability.
+//  The production implementation delegates to the system manager;
+//  tests inject a mock to verify relevance hint behavior.
+//
+//  Created by Claude on 02/19/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+#if canImport(WidgetKit)
+import AppIntents
+import WidgetKit
+
+/// Abstracts `RelevantIntentManager` so widget relevance can be tested
+/// without hitting the system API.
+@MainActor
+public protocol WidgetRelevanceUpdating: Sendable {
+    func updateRelevantIntents(_ intents: sending [RelevantIntent]) async
+}
+
+/// Production implementation that delegates to `RelevantIntentManager.shared`.
+@MainActor
+public struct SystemWidgetRelevanceUpdater: WidgetRelevanceUpdating {
+    public init() {}
+
+    public func updateRelevantIntents(_ intents: sending [RelevantIntent]) async {
+        #if os(iOS)
+        do {
+            try await RelevantIntentManager.shared.updateRelevantIntents(intents)
+        } catch {
+            // Relevance hints are best-effort; silently ignore errors.
+        }
+        #endif
+    }
+}
+#endif

--- a/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
+++ b/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
@@ -1,0 +1,208 @@
+//
+//  WidgetStateServiceRelevanceTests.swift
+//  AppServices
+//
+//  Tests for WidgetStateService's relevance hint behavior, verifying that
+//  RelevantIntents are updated when playback state changes.
+//
+//  Created by Claude on 02/19/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+#if canImport(WidgetKit)
+import AppIntents
+import AVFoundation
+import Foundation
+import PlaybackCore
+import Testing
+import WidgetKit
+@testable import Caching
+@testable import Playlist
+@testable import AppServices
+
+@MainActor
+@Suite("WidgetStateService Relevance Tests", .timeLimit(.minutes(1)))
+struct WidgetStateServiceRelevanceTests {
+
+    // MARK: - Tests
+
+    @Test("Relevance is set when playback becomes active")
+    func relevanceSetWhenPlaybackBecomesActive() async throws {
+        // Given
+        let mockRelevance = MockWidgetRelevanceUpdater()
+        let mockPlayback = MockPlaybackController()
+        let service = WidgetStateService(
+            playbackController: mockPlayback,
+            playlistService: makeTestPlaylistService(),
+            relevanceUpdater: mockRelevance
+        )
+
+        // Wait for init clear
+        await mockRelevance.waitForCallCount(1)
+
+        service.start()
+
+        // Wait for initial observation delivery (idle -> clear)
+        await mockRelevance.waitForCallCount(2)
+
+        let countBeforeChange = mockRelevance.callCount
+
+        // When
+        mockPlayback.state = .playing
+
+        // Then — wait for the relevance update
+        await mockRelevance.waitForCallCount(countBeforeChange + 1)
+        let lastCall = try #require(mockRelevance.lastCall)
+        #expect(lastCall.count == 1)
+
+        _ = service // retain
+    }
+
+    @Test("Relevance is cleared when playback stops")
+    func relevanceClearedWhenPlaybackStops() async throws {
+        // Given
+        let mockRelevance = MockWidgetRelevanceUpdater()
+        let mockPlayback = MockPlaybackController()
+        mockPlayback.state = .playing
+        let service = WidgetStateService(
+            playbackController: mockPlayback,
+            playlistService: makeTestPlaylistService(),
+            relevanceUpdater: mockRelevance
+        )
+
+        // Wait for init clear
+        await mockRelevance.waitForCallCount(1)
+
+        service.start()
+
+        // Wait for initial observation delivery (playing -> set)
+        await mockRelevance.waitForCallCount(2)
+
+        let countBeforeChange = mockRelevance.callCount
+
+        // When
+        mockPlayback.state = .idle
+
+        // Then — wait for the relevance update
+        await mockRelevance.waitForCallCount(countBeforeChange + 1)
+        let lastCall = try #require(mockRelevance.lastCall)
+        #expect(lastCall.isEmpty)
+
+        _ = service // retain
+    }
+
+    @Test("Relevance is cleared on init")
+    func relevanceClearedOnInit() async throws {
+        // Given/When
+        let mockRelevance = MockWidgetRelevanceUpdater()
+        let mockPlayback = MockPlaybackController()
+        let service = WidgetStateService(
+            playbackController: mockPlayback,
+            playlistService: makeTestPlaylistService(),
+            relevanceUpdater: mockRelevance
+        )
+
+        // Then — wait for the init clear
+        await mockRelevance.waitForCallCount(1)
+        let firstCall = try #require(mockRelevance.lastCall)
+        #expect(firstCall.isEmpty)
+
+        _ = service // retain
+    }
+}
+
+// MARK: - Helpers
+
+@MainActor
+private func makeTestPlaylistService() -> PlaylistService {
+    PlaylistService(
+        fetcher: StubPlaylistFetcher(),
+        interval: 60,
+        cacheCoordinator: CacheCoordinator(cache: InMemoryCache())
+    )
+}
+
+// MARK: - Mock Types
+
+@MainActor
+final class MockWidgetRelevanceUpdater: WidgetRelevanceUpdating {
+    private(set) var recordedCalls: [[RelevantIntent]] = []
+
+    var callCount: Int { recordedCalls.count }
+    var lastCall: [RelevantIntent]? { recordedCalls.last }
+
+    func updateRelevantIntents(_ intents: sending [RelevantIntent]) async {
+        recordedCalls.append(Array(intents))
+    }
+
+    /// Yields the main actor until at least `count` calls have been recorded.
+    func waitForCallCount(_ count: Int) async {
+        while recordedCalls.count < count {
+            await Task.yield()
+        }
+    }
+}
+
+private struct StubPlaylistFetcher: PlaylistFetcherProtocol {
+    func fetchPlaylist() async -> Playlist { .empty }
+}
+
+private final class InMemoryCache: Cache, @unchecked Sendable {
+    private var dataStorage: [String: Data] = [:]
+    private var metadataStorage: [String: CacheMetadata] = [:]
+
+    func metadata(for key: String) -> CacheMetadata? { metadataStorage[key] }
+    func data(for key: String) -> Data? { dataStorage[key] }
+
+    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
+        if let data {
+            dataStorage[key] = data
+            metadataStorage[key] = metadata
+        } else {
+            remove(for: key)
+        }
+    }
+
+    func remove(for key: String) {
+        dataStorage.removeValue(forKey: key)
+        metadataStorage.removeValue(forKey: key)
+    }
+
+    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
+        metadataStorage.map { ($0.key, $0.value) }
+    }
+
+    func clearAll() {
+        dataStorage.removeAll()
+        metadataStorage.removeAll()
+    }
+
+    func totalSize() -> Int64 {
+        dataStorage.values.reduce(0) { $0 + Int64($1.count) }
+    }
+}
+
+@Observable
+@MainActor
+final class MockPlaybackController: PlaybackController {
+    var state: PlaybackState = .idle
+    var isPlaying: Bool { state.isPlaying }
+    var isLoading: Bool { state.isLoading }
+
+    func play(reason: String) throws {}
+    func toggle(reason: String) throws {}
+    func stop() {}
+
+    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { _ in }
+    }
+
+    func installRenderTap() {}
+    func removeRenderTap() {}
+
+    #if os(iOS)
+    func handleAppDidEnterBackground() {}
+    func handleAppWillEnterForeground() {}
+    #endif
+}
+#endif

--- a/WXYC/iOS/NowPlayingWidget/NowPlayingWidget.swift
+++ b/WXYC/iOS/NowPlayingWidget/NowPlayingWidget.swift
@@ -9,6 +9,7 @@
 //
 
 import AppIntents
+import AppServices
 import Caching
 import SwiftUI
 import WidgetKit
@@ -18,9 +19,9 @@ import WXYCIntents
 
 struct NowPlayingWidget: Widget {
     let kind: String = "NowPlayingWidget"
-    
+
     var body: some WidgetConfiguration {
-        StaticConfiguration(kind: kind, provider: Provider()) { entry in
+        AppIntentConfiguration(kind: kind, intent: NowPlayingWidgetIntent.self, provider: Provider()) { entry in
             content(for: entry)
         }
         .configurationDisplayName("WXYC Now Playing")

--- a/WXYC/iOS/NowPlayingWidget/Provider.swift
+++ b/WXYC/iOS/NowPlayingWidget/Provider.swift
@@ -9,6 +9,7 @@
 //
 
 import Analytics
+import AppIntents
 import AppServices
 import Artwork
 import Caching
@@ -18,22 +19,23 @@ import Secrets
 import SwiftUI
 import WidgetKit
 
-final class Provider: TimelineProvider, Sendable {
+final class Provider: AppIntentTimelineProvider, Sendable {
     typealias Entry = NowPlayingTimelineEntry
-    
+    typealias Intent = NowPlayingWidgetIntent
+
     // Widget extensions run in a separate process from the main app.
     // They cannot access the main app's SwiftUI environment, so they
     // must create their own PlaylistService instance.
     let playlistService = PlaylistService()
     let artworkService = MultisourceArtworkService()
-    
+
     init() {
         let POSTHOG_API_KEY = Secrets.posthogApiKey
         let POSTHOG_HOST = "https://us.i.posthog.com"
         let config = PostHogConfig(apiKey: POSTHOG_API_KEY, host: POSTHOG_HOST)
         PostHogSDK.shared.setup(config)
     }
-    
+
     func placeholder(in context: Context) -> NowPlayingTimelineEntry {
         var nowPlayingItemsWithArtwork: [NowPlayingItem] = [
             NowPlayingItem.placeholder,
@@ -41,7 +43,7 @@ final class Provider: TimelineProvider, Sendable {
             NowPlayingItem.placeholder,
             NowPlayingItem.placeholder,
         ]
-        
+
         guard let (nowPlayingItem, recentItems) = nowPlayingItemsWithArtwork.popFirst() else {
             return .placeholder(family: context.family)
         }
@@ -52,83 +54,75 @@ final class Provider: TimelineProvider, Sendable {
             family: context.family
         )
     }
-    
-    func getSnapshot(in context: Context, completion: @escaping @Sendable (NowPlayingTimelineEntry) -> ()) {
+
+    func snapshot(for configuration: NowPlayingWidgetIntent, in context: Context) async -> NowPlayingTimelineEntry {
         let family = context.family
         StructuredPostHogAnalytics.shared.capture(WidgetGetSnapshot(
             family: String(describing: family)
         ))
 
-        Task {
-            let playlist = await playlistService.fetchPlaylist()
+        let playlist = await playlistService.fetchPlaylist()
 
-            var nowPlayingItems = await playlist.playcuts
-                .sorted(by: >)
-                .prefix(4)
-                .asyncMap { playcut in
-                    NowPlayingItem(
-                        playcut: playcut,
-                        artwork: try? await self.artworkService.fetchArtwork(for: playcut).toUIImage()
-                    )
-                }
-
-            // Handle empty playlist gracefully with empty state
-            guard let (nowPlayingItem, recentItems) = nowPlayingItems.popFirst() else {
-                completion(.emptyState(family: family))
-                return
+        var nowPlayingItems = await playlist.playcuts
+            .sorted(by: >)
+            .prefix(4)
+            .asyncMap { playcut in
+                NowPlayingItem(
+                    playcut: playcut,
+                    artwork: try? await self.artworkService.fetchArtwork(for: playcut).toUIImage()
+                )
             }
-            
-            let entry = NowPlayingTimelineEntry(
-                nowPlayingItem: nowPlayingItem,
-                recentItems: Array(recentItems),
-                family: family
-            )
 
-            completion(entry)
+        // Handle empty playlist gracefully with empty state
+        guard let (nowPlayingItem, recentItems) = nowPlayingItems.popFirst() else {
+            return .emptyState(family: family)
         }
+
+        return NowPlayingTimelineEntry(
+            nowPlayingItem: nowPlayingItem,
+            recentItems: Array(recentItems),
+            family: family
+        )
     }
-    
-    func getTimeline(in context: Context, completion: @escaping @Sendable (Timeline<Entry>) -> ()) {
+
+    func timeline(for configuration: NowPlayingWidgetIntent, in context: Context) async -> Timeline<NowPlayingTimelineEntry> {
         let family = context.family
         StructuredPostHogAnalytics.shared.capture(WidgetGetTimeline(
             family: String(describing: family)
         ))
 
-        Task {
-            var nowPlayingItemsWithArtwork: [NowPlayingItem] = []
-            // Default to empty state; will be replaced if we have data
-            var entry: NowPlayingTimelineEntry = .emptyState(family: family)
+        var nowPlayingItemsWithArtwork: [NowPlayingItem] = []
+        // Default to empty state; will be replaced if we have data
+        var entry: NowPlayingTimelineEntry = .emptyState(family: family)
 
-            if context.isPreview {
-                nowPlayingItemsWithArtwork = Array(repeating: .placeholder, count: 4)
-            } else {
-                let playlist = await playlistService.fetchPlaylist()
-                let playcuts = playlist
-                    .playcuts
-                    .sorted(by: >)
-                    .prefix(4)
+        if context.isPreview {
+            nowPlayingItemsWithArtwork = Array(repeating: .placeholder, count: 4)
+        } else {
+            let playlist = await playlistService.fetchPlaylist()
+            let playcuts = playlist
+                .playcuts
+                .sorted(by: >)
+                .prefix(4)
 
-                nowPlayingItemsWithArtwork = await playcuts.asyncMap { playcut in
-                    NowPlayingItem(
-                        playcut: playcut,
-                        artwork: try? await self.artworkService.fetchArtwork(for: playcut).toUIImage()
-                    )
-                }
-            }
-
-            nowPlayingItemsWithArtwork.sort(by: >)
-            if let (nowPlayingItem, recentItems) = nowPlayingItemsWithArtwork.popFirst() {
-                entry = NowPlayingTimelineEntry(
-                    nowPlayingItem: nowPlayingItem,
-                    recentItems: Array(recentItems),
-                    family: context.family
+            nowPlayingItemsWithArtwork = await playcuts.asyncMap { playcut in
+                NowPlayingItem(
+                    playcut: playcut,
+                    artwork: try? await self.artworkService.fetchArtwork(for: playcut).toUIImage()
                 )
             }
-            
-            // Schedule the next update
-            let fiveMinutes = Date.now.addingTimeInterval(5 * 60)
-            let timeline = Timeline(entries: [entry], policy: .after(fiveMinutes))
-            completion(timeline)
         }
+
+        nowPlayingItemsWithArtwork.sort(by: >)
+        if let (nowPlayingItem, recentItems) = nowPlayingItemsWithArtwork.popFirst() {
+            entry = NowPlayingTimelineEntry(
+                nowPlayingItem: nowPlayingItem,
+                recentItems: Array(recentItems),
+                family: context.family
+            )
+        }
+
+        // Schedule the next update
+        let fiveMinutes = Date.now.addingTimeInterval(5 * 60)
+        return Timeline(entries: [entry], policy: .after(fiveMinutes))
     }
 }


### PR DESCRIPTION
## Summary
- Migrate NowPlayingWidget from `StaticConfiguration` to `AppIntentConfiguration` with a minimal `NowPlayingWidgetIntent`
- Use `RelevantIntentManager` to surface the widget in the Smart Stack when the user is actively listening
- Modernize `Provider` from callback-based `TimelineProvider` to async `AppIntentTimelineProvider`

Closes #134

## Test plan
- [x] New relevance tests pass (3 tests in `WidgetStateServiceRelevanceTests`)
- [x] Full test plan passes (pre-existing `RadioPlayerTests` analytics failures are unrelated)
- [x] Build for simulator succeeds
- [ ] Verify widget previews render correctly in Xcode
- [ ] Verify widget appears in Smart Stack after listening session