### PR TITLE
Fix buffer corruption during stuck-state recovery

### DIFF
--- a/Shared/Playback/Sources/MP3Streamer/MP3Streamer.swift
+++ b/Shared/Playback/Sources/MP3Streamer/MP3Streamer.swift
@@ -77,7 +77,7 @@ public final class MP3Streamer {
     @ObservationIgnored
     private let httpClient: any HTTPStreamClientProtocol
     @ObservationIgnored
-    private let mp3Decoder: MP3StreamDecoder
+    private var mp3Decoder: MP3StreamDecoder
     @ObservationIgnored
     private let bufferQueue: PCMBufferQueue
     @ObservationIgnored
@@ -91,6 +91,8 @@ public final class MP3Streamer {
     private var httpEventTask: Task<Void, Never>?
     @ObservationIgnored
     private var playerEventTask: Task<Void, Never>?
+    @ObservationIgnored
+    private var decoderConsumerTask: Task<Void, Never>?
     @ObservationIgnored
     private let analytics: AnalyticsService?
     @ObservationIgnored
@@ -177,8 +179,11 @@ public final class MP3Streamer {
             }
         }
 
-        // Listen to decoded buffers
-        Task { [weak self] in
+        startDecoderConsumer()
+    }
+
+    private func startDecoderConsumer() {
+        decoderConsumerTask = Task { [weak self] in
             guard let self else { return }
             for await buffer in self.mp3Decoder.decodedBufferStream {
                 guard !Task.isCancelled else { break }
@@ -246,7 +251,16 @@ public final class MP3Streamer {
         httpClient.disconnect()
         audioPlayer.stop()
         bufferQueue.clear()
+
+        // Cancel the old decoder consumer and replace the decoder with a fresh instance.
+        // This eliminates stale decoded buffers that may remain in the old decoder's
+        // AsyncStream buffer (up to 32 frames with .bufferingOldest policy).
+        // The old decoder's deinit calls bufferContinuation.finish(), cleanly terminating
+        // the old consumer's for-await loop.
+        decoderConsumerTask?.cancel()
         mp3Decoder.reset()
+        mp3Decoder = MP3StreamDecoder()
+        startDecoderConsumer()
 
         streamingState = .idle
         backoffTimer.reset()
@@ -264,10 +278,17 @@ public final class MP3Streamer {
             mp3Decoder.decode(data: data)
 
         case .disconnected:
-            // Only handle if we're not intentionally stopping
-            guard streamingState != .idle else { return }
-            Log(.warning, category: .playback, "HTTP disconnected unexpectedly")
-            attemptReconnect()
+            // Only reconnect from states where an unexpected disconnect is meaningful.
+            // States like .connecting, .reconnecting, .idle, .paused, and .error must
+            // not trigger reconnect — this prevents spurious reconnects from stale
+            // .disconnected events that arrive after stop()/play() recovery cycles.
+            switch streamingState {
+            case .playing, .buffering, .stalled:
+                Log(.warning, category: .playback, "HTTP disconnected unexpectedly")
+                attemptReconnect()
+            default:
+                break
+            }
 
         case .error(let error):
             Log(.error, category: .playback, "HTTP error: \(error)")

--- a/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayer.swift
+++ b/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayer.swift
@@ -215,9 +215,17 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
 
         Log(.info, category: .playback, "Audio engine stopped")
         analytics?.capture(PlaybackStoppedEvent(reason: "audioEnginePlayer stop", duration: 0))
-        playerNode.stop()
-        engine.stop()
+
+        // Set isPlaying false first so in-flight scheduling blocks see it immediately
         stateBox.isPlaying = false
+
+        // Execute playerNode.stop() inside schedulingQueue.sync so any in-flight
+        // scheduling blocks complete first, then playerNode.stop() clears all their buffers.
+        // This prevents stale buffers from being scheduled after stop.
+        schedulingQueue.sync {
+            self.playerNode.stop()
+        }
+        engine.stop()
         scheduledBufferCount.reset()
         eventContinuation.yield(.stopped)
     }
@@ -231,6 +239,7 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
 
         schedulingQueue.async { [weak self] in
             guard let self else { return }
+            guard self.stateBox.isPlaying else { return }
 
             // If we were stalled and now have buffers, we're recovering
             // Uses atomic check-and-clear to avoid redundant lock acquisitions

--- a/Shared/Playback/Sources/MP3Streamer/STATE_MACHINE.md
+++ b/Shared/Playback/Sources/MP3Streamer/STATE_MACHINE.md
@@ -1,0 +1,188 @@
+# MP3Streamer State Machine
+
+How the streamer, HTTP client, decoder, and audio player interact.
+
+## Component Interaction
+
+```mermaid
+stateDiagram-v2
+    direction TB
+
+    state "MP3Streamer (StreamingAudioState)" as Streamer {
+        [*] --> idle
+        idle --> connecting : play()
+        connecting --> buffering : HTTP .connected
+        buffering --> playing : buffer threshold reached
+        playing --> stalled : player .stalled event
+        stalled --> playing : buffer threshold reached
+        playing --> idle : stop()
+        buffering --> idle : stop()
+        connecting --> idle : stop()
+        stalled --> idle : stop()
+        playing --> error : HTTP .error / player .error
+        buffering --> error : HTTP .error
+        connecting --> error : connect() throws
+        error --> idle : stop()
+        error --> connecting : play() [calls stop() first]
+        stalled --> connecting : play() [calls stop() first]
+        connecting --> connecting : play() [calls stop() first]
+        buffering --> connecting : play() [calls stop() first]
+        playing --> playing : play() [no-op]
+        paused --> playing : play() [resume]
+        playing --> paused : pause()
+
+        state "Reconnect Logic" as Reconnect {
+            playing --> reconnecting : HTTP .disconnected
+            buffering --> reconnecting : HTTP .disconnected
+            stalled --> reconnecting : HTTP .disconnected
+            reconnecting --> connecting : backoff timer fires
+        }
+
+        note right of idle
+            .disconnected events are
+            IGNORED in connecting,
+            reconnecting, idle, paused,
+            and error states
+        end note
+    }
+```
+
+## HTTP Client Events
+
+```mermaid
+stateDiagram-v2
+    [*] --> disconnected
+    disconnected --> connected : connect()
+    connected --> streaming : data arrives
+    streaming --> disconnected : disconnect() / network loss
+    connected --> disconnected : disconnect()
+```
+
+Events emitted: `.connected`, `.data(Data)`, `.disconnected`, `.error(Error)`
+
+## Audio Engine Player
+
+```mermaid
+stateDiagram-v2
+    [*] --> stopped
+    stopped --> playing : play()
+    playing --> stopped : stop()
+    playing --> paused : pause()
+    paused --> playing : play()
+```
+
+`stop()` sets `isPlaying = false` before draining the scheduling queue via `schedulingQueue.sync {}`, then calls `playerNode.stop()` inside that sync block. The `scheduleBuffers()` async block guards on `isPlaying` as defense-in-depth.
+
+Events emitted: `.started`, `.stopped`, `.paused`, `.stalled`, `.recoveredFromStall`, `.needsMoreBuffers`, `.error(Error)`
+
+## Decoder Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> waiting
+    waiting --> decoding : decode\(data)
+    decoding --> waiting : yields PCM buffer
+    decoding --> [*] : stop() replaces decoder
+```
+
+On `stop()`, the decoder is replaced with a fresh instance. The old decoder's `deinit` calls `bufferContinuation.finish()`, terminating its `AsyncStream` and discarding up to 32 stale PCM buffers.
+
+## Data Flow
+
+```mermaid
+flowchart LR
+    Server["HTTP Server"]
+    HTTP["HTTPStreamClient"]
+    Decoder["MP3StreamDecoder"]
+    Streamer["MP3Streamer"]
+    Player["AudioEnginePlayer"]
+    Queue["PCMBufferQueue"]
+
+    Server -- "MP3 bytes" --> HTTP
+    HTTP -- ".data(Data)" --> Streamer
+    HTTP -- ".connected / .disconnected / .error" --> Streamer
+    Streamer -- "decode(data:)" --> Decoder
+    Decoder -- "decodedBufferStream<br>(PCM buffers)" --> Streamer
+    Streamer -- "enqueue<br>(buffering/stalled)" --> Queue
+    Queue -- "dequeueAll" --> Streamer
+    Streamer -- "scheduleBuffer()<br>(playing: direct)" --> Player
+    Streamer -- "scheduleBuffers()<br>(from queue)" --> Player
+    Player -- ".stalled / .recoveredFromStall<br>.needsMoreBuffers / .error" --> Streamer
+    Streamer -- "connect() / disconnect()" --> HTTP
+    Streamer -- "play() / stop()" --> Player
+    Streamer -- "reset() / replace" --> Decoder
+```
+
+## PlayerStateBox (AudioEnginePlayer internal)
+
+Thread-safe atomic state inside `AudioEnginePlayer` that drives stall detection and the scheduling queue guard.
+
+```mermaid
+stateDiagram-v2
+    state "isPlaying" as IP {
+        [*] --> false_p
+        false_p --> true_p : play()
+        true_p --> false_p : stop() / pause()
+    }
+
+    state "isStalled" as IS {
+        [*] --> false_s
+        false_s --> true_s : setStalledIfPlaying()<br>[count == 0 && isPlaying]
+        true_s --> false_s : clearStalledIfSet()<br>[new buffers arrive]
+    }
+```
+
+The `stop()` sequence depends on this ordering:
+1. `stateBox.isPlaying = false` -- in-flight scheduling blocks see this immediately
+2. `schedulingQueue.sync { playerNode.stop() }` -- drains queue, then clears buffers
+3. `scheduleBuffers()` guards on `stateBox.isPlaying` as defense-in-depth
+
+## State Mapping
+
+`StreamingAudioState` (internal, 9 cases) is projected to `PlayerState` (public, 5 cases) for consumers.
+
+```mermaid
+flowchart LR
+    subgraph "StreamingAudioState (MP3Streamer)"
+        idle["idle"]
+        paused["paused"]
+        connecting["connecting"]
+        buffering["buffering"]
+        reconnecting["reconnecting"]
+        playing_s["playing"]
+        stalled_s["stalled"]
+        error_s["error"]
+    end
+
+    subgraph "PlayerState (public API)"
+        ps_idle["idle"]
+        ps_loading["loading"]
+        ps_playing["playing"]
+        ps_stalled["stalled"]
+        ps_error["error"]
+    end
+
+    idle --> ps_idle
+    paused --> ps_idle
+    connecting --> ps_loading
+    buffering --> ps_loading
+    reconnecting --> ps_loading
+    playing_s --> ps_playing
+    stalled_s --> ps_stalled
+    error_s --> ps_error
+```
+
+## Reconnect Guard
+
+The `.disconnected` handler only triggers `attemptReconnect()` from these states:
+
+| State | Reconnect? | Reason |
+|-------|-----------|--------|
+| `.playing` | Yes | Unexpected disconnect during playback |
+| `.buffering` | Yes | Connection lost while buffering |
+| `.stalled` | Yes | Connection lost while stalled |
+| `.connecting` | No | Stale event from stop()/play() cycle |
+| `.reconnecting` | No | Already reconnecting |
+| `.idle` | No | Intentional stop |
+| `.paused` | No | User paused |
+| `.error` | No | Already in error handling |

--- a/Shared/Playback/Tests/MP3StreamerTests/MP3StreamerTests.swift
+++ b/Shared/Playback/Tests/MP3StreamerTests/MP3StreamerTests.swift
@@ -453,7 +453,10 @@ struct MP3StreamerStuckStateRecoveryTests {
             return
         }
 
-        // Simulate stall
+        // Wait for decoder to finish all pending data so no new buffers auto-recover
+        try await Task.sleep(for: .milliseconds(300))
+
+        // Simulate stall — with no pending data, the stall state should persist
         mockPlayer.simulateStall()
         try await Task.sleep(for: .milliseconds(50))
         #expect(streamer.streamingState == .stalled)
@@ -510,6 +513,114 @@ struct MP3StreamerStuckStateRecoveryTests {
         // Should have torn down and reconnected
         #expect(mockHTTP.connectCallCount > connectCountAfterFirst,
                 "play() from \(stateAfterFirstPlay) should tear down and reconnect")
+    }
+
+    @Test("play() from stuck state does not trigger spurious reconnect", .tags(.stuckStateRecovery))
+    func playFromStuckStateNoSpuriousReconnect() async throws {
+        // Tests the primary bug: when play() calls stop() for stuck-state recovery,
+        // stop() calls httpClient.disconnect() which yields a .disconnected event.
+        // Since play() and stop() run synchronously on MainActor, this event isn't
+        // processed until play() returns. By then, state has moved to .connecting.
+        // The old guard (state != .idle) would pass and trigger attemptReconnect(),
+        // causing a duplicate connection.
+        let config = MP3StreamerConfiguration(url: Self.testStreamURL)
+        let mockHTTP = MockHTTPStreamClient()
+        let mockPlayer = MockAudioEnginePlayer()
+
+        // Don't provide test data — we only care about connection count
+        mockHTTP.testData = nil
+
+        let streamer = MP3Streamer(
+            configuration: config,
+            httpClient: mockHTTP,
+            audioPlayer: mockPlayer
+        )
+
+        // Start initial connection
+        streamer.play()
+        try await Task.sleep(for: .milliseconds(100))
+        #expect(mockHTTP.connectCallCount == 1)
+
+        // Manually yield .disconnected to put the streamer into reconnect mode.
+        // This simulates a real disconnect that makes the streamer attempt recovery.
+        mockHTTP.yield(.disconnected)
+        try await Task.sleep(for: .milliseconds(100))
+
+        // Now the streamer is reconnecting (or has reconnected). Record connect count.
+        let connectCountBefore = mockHTTP.connectCallCount
+
+        // Call play() again. This triggers stop() → disconnect() → .disconnected event.
+        // After stop() returns, play() sets state to .connecting and calls connect().
+        // The stale .disconnected event arrives after state is .connecting.
+        // With the bug: that event passes guard (state != .idle) and calls
+        // attemptReconnect(), adding an extra connect.
+        streamer.play()
+
+        // Allow time for the stale .disconnected to be processed
+        try await Task.sleep(for: .milliseconds(300))
+
+        // Exactly 1 new connect should have happened (from play()).
+        // If 2+ new connects happened, the stale .disconnected triggered a spurious reconnect.
+        let newConnections = mockHTTP.connectCallCount - connectCountBefore
+        #expect(newConnections == 1,
+                "play() recovery should trigger exactly 1 new connect, not more")
+    }
+
+    @Test("play() from stuck state does not schedule stale buffers", .tags(.stuckStateRecovery))
+    func playFromStuckStateNoStaleBuffers() async throws {
+        let config = MP3StreamerConfiguration(
+            url: Self.testStreamURL,
+            minimumBuffersBeforePlayback: 3
+        )
+        let mockHTTP = MockHTTPStreamClient()
+        let mockPlayer = MockAudioEnginePlayer()
+        mockPlayer.immediatelyRequestMoreBuffers = false
+
+        let testData = try TestAudioBufferFactory.loadMP3TestData()
+        mockHTTP.testData = testData
+
+        let streamer = MP3Streamer(
+            configuration: config,
+            httpClient: mockHTTP,
+            audioPlayer: mockPlayer
+        )
+
+        // Get to playing state
+        streamer.play()
+        for _ in 0..<20 {
+            try await Task.sleep(for: .milliseconds(100))
+            if case .playing = streamer.streamingState { break }
+        }
+
+        guard case .playing = streamer.streamingState else {
+            return // Skip if we couldn't reach playing state
+        }
+
+        // Wait for decoder to finish processing all data
+        try await Task.sleep(for: .milliseconds(300))
+
+        // Capture the buffer identities from the first session
+        let firstSessionBuffers = Set(mockPlayer.scheduledBuffers.map { ObjectIdentifier($0) })
+        #expect(!firstSessionBuffers.isEmpty, "Should have scheduled buffers in first session")
+
+        // Clear the mock's buffer list so we can track only post-recovery buffers
+        mockPlayer.clearScheduledBuffers()
+
+        // Recover via play() — stop() + reconnect with fresh data
+        mockHTTP.testData = testData
+        streamer.play()
+
+        // Wait for new buffers to be scheduled
+        for _ in 0..<20 {
+            try await Task.sleep(for: .milliseconds(100))
+            if !mockPlayer.scheduledBuffers.isEmpty { break }
+        }
+
+        // Verify no stale buffers from the first session appear in the second
+        let secondSessionBuffers = Set(mockPlayer.scheduledBuffers.map { ObjectIdentifier($0) })
+        let staleBuffers = firstSessionBuffers.intersection(secondSessionBuffers)
+        #expect(staleBuffers.isEmpty,
+                "Stale buffers from first session should not leak into second session")
     }
 
     @Test("isPlaying is true after recovering from error via play()", .tags(.stuckStateRecovery))

--- a/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioEnginePlayer.swift
+++ b/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioEnginePlayer.swift
@@ -112,6 +112,11 @@ public final class MockAudioEnginePlayer: @preconcurrency AudioEnginePlayerProto
         eventContinuation.yield(event)
     }
 
+    /// Clear the scheduled buffers list (for tracking across sessions)
+    public func clearScheduledBuffers() {
+        scheduledBuffers.removeAll()
+    }
+
     /// Simulate a stall
     public func simulateStall() {
         eventContinuation.yield(.stalled)

--- a/Shared/Playback/Tests/RadioPlayerTests/RadioPlayerControllerTests.swift
+++ b/Shared/Playback/Tests/RadioPlayerTests/RadioPlayerControllerTests.swift
@@ -38,8 +38,11 @@ import Core
 final class MockAudioSession: AudioSessionProtocol {
     var setActiveCallCount = 0
     var lastActiveState: Bool?
+    var outputLatency: TimeInterval = 0
 
     func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, options: AVAudioSession.CategoryOptions) throws {}
+
+    func setCategory(_ category: AVAudioSession.Category, mode: AVAudioSession.Mode, policy: AVAudioSession.RouteSharingPolicy, options: AVAudioSession.CategoryOptions) throws {}
 
     func setActive(_ active: Bool, options: AVAudioSession.SetActiveOptions) throws {
         setActiveCallCount += 1


### PR DESCRIPTION
## Summary

- Fix spurious reconnect from stale `.disconnected` event during `stop()`/`play()` recovery by restricting the reconnect guard to only `.playing`, `.buffering`, `.stalled` states
- Eliminate stale decoded buffers by replacing `MP3StreamDecoder` with a fresh instance on `stop()` instead of just resetting internal state
- Prevent scheduling queue race in `AudioEnginePlayer.stop()` by setting `isPlaying=false` first, draining the queue via `schedulingQueue.sync {}`, and adding an `isPlaying` guard in `scheduleBuffers()`
- Add state machine documentation with Mermaid diagrams

Closes #136

## Test plan

- [x] New test: `play() from stuck state does not trigger spurious reconnect` -- verifies exactly 1 new connect happens, not 2
- [x] New test: `play() from stuck state does not schedule stale buffers` -- verifies no buffer identity overlap across sessions
- [x] Fix pre-existing `play() from stalled state resets and reconnects` timing issue (wait for decoder to drain before simulating stall)
- [x] All 82 MP3StreamerTests pass (6 stuck-state recovery tests, including 2 new)