### PR TITLE
Migrate artwork and entity resolution to backend proxy

### DIFF
--- a/Shared/Artwork/Package.swift
+++ b/Shared/Artwork/Package.swift
@@ -9,14 +9,13 @@ let package = Package(
         .package(name: "Core", path: "../Core"),
         .package(name: "Caching", path: "../Caching"),
         .package(name: "Playlist", path: "../Playlist"),
-        .package(name: "Secrets", path: "../Secrets"),
         .package(name: "OpenNSFW", path: "../OpenNSFW"),
         .package(name: "Logger", path: "../Logger"),
     ],
     targets: [
         .target(
             name: "Artwork",
-            dependencies: ["Core", "Caching", "Playlist", "Secrets", "OpenNSFW", "Logger"]
+            dependencies: ["Core", "Caching", "Playlist", "OpenNSFW", "Logger"]
         ),
         .testTarget(
             name: "ArtworkTests",

--- a/Shared/Artwork/Sources/Artwork/DiscogsArtworkService.swift
+++ b/Shared/Artwork/Sources/Artwork/DiscogsArtworkService.swift
@@ -2,105 +2,90 @@
 //  DiscogsArtworkService.swift
 //  Artwork
 //
-//  Fetches album artwork from Discogs API.
-//  Falls back to artist images when album art is unavailable.
+//  Fetches album artwork via the backend proxy endpoint.
+//  Falls back gracefully when no token provider is available.
 //
 //  Created by Jake Bromberg on 04/12/23.
 //  Copyright © 2023 WXYC. All rights reserved.
 //
 
-import Secrets
 import Foundation
 import Core
 import CoreGraphics
 import Playlist
 
 final class DiscogsArtworkService: ArtworkService {
-    private static let key    = Secrets.discogsApiKeyV2_5
-    private static let secret = Secrets.discogsApiSecretV2_5
-
+    private let baseURL: URL
+    private let tokenProvider: SessionTokenProvider?
     private let session: WebSession
     private let decoder = JSONDecoder()
 
-    init(session: WebSession = URLSession.shared) {
+    init(
+        baseURL: URL = URL(string: "https://api.wxyc.org")!,
+        tokenProvider: SessionTokenProvider? = nil,
+        session: WebSession = URLSession.shared
+    ) {
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
         self.session = session
     }
 
     func fetchArtwork(for playcut: Playcut) async throws -> CGImage {
-        let url: URL
-        if let albumArtURL = try await fetchAlbumArtURL(for: playcut) {
-            url = albumArtURL
-        } else if let artistArtURL = try await fetchArtistArtURL(for: playcut) {
-            url = artistArtURL
-        } else {
+        let response = try await fetchArtworkResponse(for: playcut)
+
+        guard let urlString = response.artworkUrl, let url = URL(string: urlString) else {
             throw ServiceError.noResults
         }
 
         let imageData = try await session.data(from: url)
-        
+
         guard let cgImage = createCGImage(from: imageData) else {
             throw ServiceError.noResults
         }
-    
+
         return cgImage
     }
-    
-    private func fetchAlbumArtURL(for playcut: Playcut) async throws -> URL? {
-        let searchURL = makeArtworkSearchURL(for: playcut)
-        return try await fetchArtURL(for: searchURL)
-    }
-    
-    private func makeArtworkSearchURL(for playcut: Playcut) -> URL {
-        var releaseTitle: String? = playcut.releaseTitle
-        if let title = playcut.releaseTitle,
-           title.lowercased() == "s/t" {
-            releaseTitle = playcut.artistName
+
+    private func fetchArtworkResponse(for playcut: Playcut) async throws -> ArtworkSearchResponse {
+        var components = URLComponents(url: baseURL.appending(path: "proxy/artwork/search"), resolvingAgainstBaseURL: false)!
+        var queryItems = [URLQueryItem(name: "artistName", value: playcut.artistName)]
+
+        if let releaseTitle = playcut.releaseTitle {
+            let title = releaseTitle.lowercased() == "s/t" ? playcut.artistName : releaseTitle
+            queryItems.append(URLQueryItem(name: "releaseTitle", value: title))
         }
-        
-        var searchTerms = [
-            playcut.artistName,
-        ]
-        
-        if let releaseTitle {
-            searchTerms.append(releaseTitle)
+
+        components.queryItems = queryItems
+
+        guard let url = components.url else {
+            throw ServiceError.noResults
         }
-        
-        var components = URLComponents(string: "https://api.discogs.com")!
-        components.path = "/database/search"
-        components.queryItems = .init([
-            "q" : searchTerms.joined(separator: " "),
-            "key" : Self.key,
-            "secret" : Self.secret,
-        ])
-    
-        return components.url!
+
+        let data: Data
+        if let tokenProvider {
+            let token = try await tokenProvider.token()
+            data = try await authenticatedData(from: url, token: token)
+        } else {
+            data = try await session.data(from: url)
+        }
+
+        return try decoder.decode(ArtworkSearchResponse.self, from: data)
     }
-    
-    func fetchArtistArtURL(for playcut: Playcut) async throws -> URL? {
-        let searchURL = makeArtistSearchURL(for: playcut)
-        return try await fetchArtURL(for: searchURL)
+
+    private func authenticatedData(from url: URL, token: String) async throws -> Data {
+        var request = URLRequest(url: url)
+        request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        let (data, _) = try await URLSession.shared.data(for: request)
+        return data
     }
-    
-    func makeArtistSearchURL(for playcut: Playcut) -> URL {
-        var components = URLComponents(string: "https://api.discogs.com")!
-        components.path = "/database/search"
-        components.queryItems = .init([
-            "type" : "artist",
-            "title" : playcut.artistName,
-            "key" : Self.key,
-            "secret" : Self.secret,
-        ])
-    
-        return components.url!
-    }
-    
-    func fetchArtURL(for searchURL: URL) async throws -> URL? {
-        let searchData = try await session.data(from: searchURL)
-        let searchResponse = try decoder.decode(Discogs.SearchResults.self, from: searchData)
-        
-        let imageURLs: [URL] = searchResponse.results.map(\.coverImage)
-        return imageURLs.first(where: { !$0.lastPathComponent.hasPrefix("spacer.gif") })
-    }
+}
+
+// MARK: - Backend Response Model
+
+struct ArtworkSearchResponse: Codable, Sendable {
+    let artworkUrl: String?
+    let source: String?
+    let confidence: Double?
 }
 
 extension [URLQueryItem] {
@@ -116,7 +101,7 @@ public struct Discogs {
     public struct SearchResults: Codable {
         public let results: [SearchResult]
     }
-    
+
     public struct SearchResult: Codable {
         public let coverImage: URL
         public let masterId: Int?
@@ -126,7 +111,7 @@ public struct Discogs {
         public let year: String?
         public let uri: String?
         public let resourceUrl: String?
-        
+
         enum CodingKeys: String, CodingKey {
             case coverImage = "cover_image"
             case masterId = "master_id"
@@ -137,16 +122,15 @@ public struct Discogs {
             case uri
             case resourceUrl = "resource_url"
         }
-        
+
         /// Constructs the full Discogs web URL from the uri field or id/type
         public var discogsWebURL: URL? {
             // Prefer uri if available
-            if let uri = uri {
+            if let uri {
                 return URL(string: "https://www.discogs.com\(uri)")
             }
-            
+
             // Fallback: construct URL from type and id
-            // Examples: /release/12345, /master/67890, /artist/123
             let path: String
             switch type {
             case "release":
@@ -158,37 +142,36 @@ public struct Discogs {
             case "label":
                 path = "/label/\(id)"
             default:
-                // For unknown types, try a generic approach
                 path = "/\(type)/\(id)"
             }
-            
+
             return URL(string: "https://www.discogs.com\(path)")
         }
-            
+
         /// Parsed release year as Int
         public var releaseYear: Int? {
-            guard let year = year else { return nil }
+            guard let year else { return nil }
             return Int(year)
         }
-    
+
         /// First label name if available
         public var primaryLabel: String? {
             label?.first
         }
     }
-    
+
     // MARK: - Artist Models
-    
+
     public struct Artist: Codable {
         public let id: Int
         public let name: String
         public let profile: String?
         public let urls: [String]?
         public let images: [ArtistImage]?
-        
+
         /// Finds Wikipedia URL from the urls array
         public var wikipediaURL: URL? {
-            guard let urls = urls else { return nil }
+            guard let urls else { return nil }
             let wikipediaString = urls.first { url in
                 url.lowercased().contains("wikipedia.org") ||
                 url.lowercased().contains("en.wikipedia")
@@ -196,14 +179,14 @@ public struct Discogs {
             return wikipediaString.flatMap { URL(string: $0) }
         }
     }
-    
+
     public struct ArtistImage: Codable {
         let uri: String
         let type: String
     }
-    
+
     // MARK: - Release Models (for detailed info)
-        
+
     public struct Release: Codable {
         let id: Int
         let title: String
@@ -211,51 +194,51 @@ public struct Discogs {
         let labels: [Label]?
         let artists: [ReleaseArtist]?
         let uri: String?
-        
+
         struct Label: Codable {
             let name: String
             let id: Int
         }
-        
+
         struct ReleaseArtist: Codable {
             let id: Int
             let name: String
         }
-        
+
         public var primaryLabel: String? {
             labels?.first?.name
         }
-        
+
         public var primaryArtistId: Int? {
             artists?.first?.id
         }
-    
+
         public var discogsWebURL: URL? {
-            guard let uri = uri else { return nil }
+            guard let uri else { return nil }
             return URL(string: "https://www.discogs.com\(uri)")
         }
     }
-    
+
     // MARK: - Master Release Models
-    
+
     public struct Master: Codable {
         let id: Int
         let title: String
         let year: Int?
         let uri: String?
         let artists: [ReleaseArtist]?
-        
+
         struct ReleaseArtist: Codable {
             let id: Int
             let name: String
         }
-        
+
         public var primaryArtistId: Int? {
             artists?.first?.id
         }
 
         public var discogsWebURL: URL? {
-            guard let uri = uri else { return nil }
+            guard let uri else { return nil }
             return URL(string: "https://www.discogs.com\(uri)")
         }
     }

--- a/Shared/Core/Sources/Core/Models and Services/SessionTokenProvider.swift
+++ b/Shared/Core/Sources/Core/Models and Services/SessionTokenProvider.swift
@@ -1,0 +1,23 @@
+//
+//  SessionTokenProvider.swift
+//  Core
+//
+//  Protocol for providing session tokens to services that need authenticated
+//  access to backend proxy endpoints. Implementations live in MusicShareKit
+//  (full AuthenticationService) and AppServices (keychain-only fallback).
+//
+//  Created by Jake Bromberg on 03/03/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Provides a session token for authenticated API calls.
+///
+/// Services that call backend proxy endpoints accept an optional
+/// `SessionTokenProvider` at initialization. When present, they include
+/// the token in an `Authorization: Bearer <token>` header.
+public protocol SessionTokenProvider: Sendable {
+    /// Returns a valid session token, performing authentication if needed.
+    func token() async throws -> String
+}

--- a/Shared/Metadata/Package.swift
+++ b/Shared/Metadata/Package.swift
@@ -10,13 +10,12 @@ let package = Package(
         .package(name: "Core", path: "../Core"),
         .package(name: "Caching", path: "../Caching"),
         .package(name: "Playlist", path: "../Playlist"),
-        .package(name: "Secrets", path: "../Secrets"),
         .package(name: "Logger", path: "../Logger"),
     ],
     targets: [
         .target(
             name: "Metadata",
-            dependencies: ["Artwork", "Core", "Caching", "Playlist", "Secrets", "Logger"]
+            dependencies: ["Artwork", "Core", "Caching", "Playlist", "Logger"]
         ),
         .testTarget(
             name: "MetadataTests",

--- a/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
+++ b/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
@@ -2,14 +2,13 @@
 //  DiscogsEntityResolver.swift
 //  Metadata
 //
-//  Resolves Discogs artist/release entities for playcut enrichment.
+//  Resolves Discogs artist/release entities via the backend proxy endpoint.
 //
 //  Created by Jake Bromberg on 11/26/25.
 //  Copyright © 2025 WXYC. All rights reserved.
 //
 
 import Foundation
-import Secrets
 import Core
 import Caching
 
@@ -20,99 +19,87 @@ public protocol DiscogsEntityResolver: Sendable {
     func resolveMaster(id: Int) async throws -> String
 }
 
-/// Resolves Discogs entity IDs by calling the Discogs API
+/// Resolves Discogs entity IDs by calling the backend proxy endpoint
 public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
+    private let baseURL: URL
+    private let tokenProvider: SessionTokenProvider?
     private let session: WebSession
     private let decoder: JSONDecoder
     private let cache: CacheCoordinator
-    
+
     /// Cache lifespan: 30 days (entity names essentially never change)
     private static let cacheLifespan: TimeInterval = 60 * 60 * 24 * 30
-    
+
     /// Shared instance for convenience
     public static let shared = DiscogsAPIEntityResolver()
-    
-    init(session: WebSession = URLSession.shared, cache: CacheCoordinator = .AlbumArt) {
+
+    init(
+        baseURL: URL = URL(string: "https://api.wxyc.org")!,
+        tokenProvider: SessionTokenProvider? = nil,
+        session: WebSession = URLSession.shared,
+        cache: CacheCoordinator = .AlbumArt
+    ) {
+        self.baseURL = baseURL
+        self.tokenProvider = tokenProvider
         self.session = session
         self.decoder = JSONDecoder()
         self.cache = cache
     }
-    
+
     public func resolveArtist(id: Int) async throws -> String {
-        let cacheKey = "discogs-artist-\(id)"
-        
-        // Check cache first
-        if let cached: String = try? await cache.value(for: cacheKey) {
-            return cached
-        }
-        
-        let url = makeURL(path: "/artists/\(id)")
-        let data = try await session.data(from: url)
-        let artist = try decoder.decode(DiscogsArtist.self, from: data)
-        
-        // Cache the result
-        await cache.set(value: artist.name, for: cacheKey, lifespan: Self.cacheLifespan)
-        
-        return artist.name
+        try await resolve(type: "artist", id: id)
     }
-    
+
     public func resolveRelease(id: Int) async throws -> String {
-        let cacheKey = "discogs-release-\(id)"
-        
-        // Check cache first
-        if let cached: String = try? await cache.value(for: cacheKey) {
-            return cached
-        }
-        
-        let url = makeURL(path: "/releases/\(id)")
-        let data = try await session.data(from: url)
-        let release = try decoder.decode(DiscogsRelease.self, from: data)
-        
-        // Cache the result
-        await cache.set(value: release.title, for: cacheKey, lifespan: Self.cacheLifespan)
-        
-        return release.title
+        try await resolve(type: "release", id: id)
     }
-    
+
     public func resolveMaster(id: Int) async throws -> String {
-        let cacheKey = "discogs-master-\(id)"
-        
+        try await resolve(type: "master", id: id)
+    }
+
+    private func resolve(type: String, id: Int) async throws -> String {
+        let cacheKey = "discogs-\(type)-\(id)"
+
         // Check cache first
         if let cached: String = try? await cache.value(for: cacheKey) {
             return cached
         }
-        
-        let url = makeURL(path: "/masters/\(id)")
-        let data = try await session.data(from: url)
-        let master = try decoder.decode(DiscogsMaster.self, from: data)
-        
-        // Cache the result
-        await cache.set(value: master.title, for: cacheKey, lifespan: Self.cacheLifespan)
-        
-        return master.title
-    }
-    
-    private func makeURL(path: String) -> URL {
-        var components = URLComponents(string: "https://api.discogs.com")!
-        components.path = path
+
+        var components = URLComponents(url: baseURL.appending(path: "proxy/entity/resolve"), resolvingAgainstBaseURL: false)!
         components.queryItems = [
-            URLQueryItem(name: "key", value: Secrets.discogsApiKeyV2_5),
-            URLQueryItem(name: "secret", value: Secrets.discogsApiSecretV2_5)
+            URLQueryItem(name: "type", value: type),
+            URLQueryItem(name: "id", value: String(id))
         ]
-        return components.url!
+
+        guard let url = components.url else {
+            throw ServiceError.noResults
+        }
+
+        let data: Data
+        if let tokenProvider {
+            let token = try await tokenProvider.token()
+            var request = URLRequest(url: url)
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+            let (responseData, _) = try await URLSession.shared.data(for: request)
+            data = responseData
+        } else {
+            data = try await session.data(from: url)
+        }
+
+        let response = try decoder.decode(EntityResolveResponse.self, from: data)
+
+        // Cache the result
+        await cache.set(value: response.name, for: cacheKey, lifespan: Self.cacheLifespan)
+
+        return response.name
     }
 }
 
-// MARK: - Discogs API Response Models
+// MARK: - Backend Response Model
 
-private struct DiscogsArtist: Codable, Sendable {
+private struct EntityResolveResponse: Codable, Sendable {
     let name: String
-}
-
-private struct DiscogsRelease: Codable, Sendable {
-    let title: String
-}
-
-private struct DiscogsMaster: Codable, Sendable {
-    let title: String
+    let type: String
+    let id: Int
 }

--- a/Shared/Metadata/Tests/MetadataTests/DiscogsAPIEntityResolverCachingTests.swift
+++ b/Shared/Metadata/Tests/MetadataTests/DiscogsAPIEntityResolverCachingTests.swift
@@ -2,7 +2,8 @@
 //  DiscogsAPIEntityResolverCachingTests.swift
 //  Metadata
 //
-//  Tests for DiscogsAPIEntityResolver caching functionality
+//  Tests for DiscogsAPIEntityResolver caching functionality.
+//  The resolver now calls the backend proxy at /proxy/entity/resolve.
 //
 //  Created by Jake Bromberg on 11/30/25.
 //  Copyright © 2025 WXYC. All rights reserved.
@@ -24,17 +25,17 @@ final class EntityResolverMockCache: Cache, @unchecked Sendable {
     var keysSet: [String] = []
     var lastGetKey: String?
     var lastSetKey: String?
-    
+
     func metadata(for key: String) -> CacheMetadata? {
         getCallCount += 1
         lastGetKey = key
         return metadataStorage[key]
     }
-    
+
     func data(for key: String) -> Data? {
-        return dataStorage[key]
+        dataStorage[key]
     }
-    
+
     func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
         setCallCount += 1
         lastSetKey = key
@@ -46,12 +47,12 @@ final class EntityResolverMockCache: Cache, @unchecked Sendable {
             remove(for: key)
         }
     }
-    
+
     func remove(for key: String) {
         dataStorage.removeValue(forKey: key)
         metadataStorage.removeValue(forKey: key)
     }
-    
+
     func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
         metadataStorage.map { ($0.key, $0.value) }
     }
@@ -73,22 +74,23 @@ final class EntityResolverMockWebSession: WebSession, @unchecked Sendable {
     var requestedURLs: [URL] = []
     var requestCount = 0
     var shouldFail = false
-    
+
     func data(from url: URL) async throws -> Data {
         requestCount += 1
         requestedURLs.append(url)
-        
+
         if shouldFail {
             throw URLError(.badServerResponse)
         }
-        
-        // Match response based on URL path
+
+        // Match response based on URL path or query parameters
+        let urlString = url.absoluteString
         for (pattern, data) in responses {
-            if url.path.contains(pattern) {
+            if urlString.contains(pattern) {
                 return data
             }
         }
-    
+
         throw URLError(.resourceUnavailable)
     }
 }
@@ -97,7 +99,7 @@ final class EntityResolverMockWebSession: WebSession, @unchecked Sendable {
 
 @Suite("DiscogsAPIEntityResolver Caching Tests")
 struct DiscogsAPIEntityResolverCachingTests {
-    
+
     @Test("resolveArtist returns cached name without API call")
     func resolveArtistReturnsCached() async throws {
         // Given
@@ -105,45 +107,46 @@ struct DiscogsAPIEntityResolverCachingTests {
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
+
         // Pre-populate cache with artist name
         await cache.set(value: "Cached Artist Name", for: "discogs-artist-12345", lifespan: 3600)
         mockCache.getCallCount = 0  // Reset after setup
-        
+
         // When
         let result = try await resolver.resolveArtist(id: 12345)
-        
+
         // Then
         #expect(result == "Cached Artist Name")
         #expect(mockSession.requestCount == 0, "Should not make API call when cached")
     }
-    
-    @Test("resolveArtist fetches from API and caches on miss")
+
+    @Test("resolveArtist fetches from backend proxy and caches on miss")
     func resolveArtistFetchesAndCaches() async throws {
         // Given
         let mockCache = EntityResolverMockCache()
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
-        // Mock API response
-        let artistResponse = """
+
+        // Mock backend proxy response
+        let proxyResponse = """
         {
-            "id": 99999,
-            "name": "New Artist From API"
+            "name": "New Artist From API",
+            "type": "artist",
+            "id": 99999
         }
         """.data(using: .utf8)!
-        mockSession.responses["/artists/99999"] = artistResponse
-    
+        mockSession.responses["type=artist&id=99999"] = proxyResponse
+
         // When
         let result = try await resolver.resolveArtist(id: 99999)
-        
+
         // Then
         #expect(result == "New Artist From API")
         #expect(mockSession.requestCount == 1, "Should make exactly one API call")
         #expect(mockCache.keysSet.contains("discogs-artist-99999"), "Should cache the result")
     }
-    
+
     @Test("resolveRelease returns cached title without API call")
     func resolveReleaseReturnsCached() async throws {
         // Given
@@ -151,45 +154,46 @@ struct DiscogsAPIEntityResolverCachingTests {
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
+
         // Pre-populate cache
         await cache.set(value: "Cached Album Title", for: "discogs-release-54321", lifespan: 3600)
         mockCache.getCallCount = 0
-        
+
         // When
         let result = try await resolver.resolveRelease(id: 54321)
-        
+
         // Then
         #expect(result == "Cached Album Title")
         #expect(mockSession.requestCount == 0)
     }
-    
-    @Test("resolveRelease fetches from API and caches on miss")
+
+    @Test("resolveRelease fetches from backend proxy and caches on miss")
     func resolveReleaseFetchesAndCaches() async throws {
         // Given
         let mockCache = EntityResolverMockCache()
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
-        // Mock API response
-        let releaseResponse = """
+
+        // Mock backend proxy response
+        let proxyResponse = """
         {
-            "id": 88888,
-            "title": "New Album From API"
+            "name": "New Album From API",
+            "type": "release",
+            "id": 88888
         }
         """.data(using: .utf8)!
-        mockSession.responses["/releases/88888"] = releaseResponse
-    
+        mockSession.responses["type=release&id=88888"] = proxyResponse
+
         // When
         let result = try await resolver.resolveRelease(id: 88888)
-        
+
         // Then
         #expect(result == "New Album From API")
         #expect(mockSession.requestCount == 1)
         #expect(mockCache.keysSet.contains("discogs-release-88888"))
     }
-    
+
     @Test("resolveMaster returns cached title without API call")
     func resolveMasterReturnsCached() async throws {
         // Given
@@ -197,45 +201,46 @@ struct DiscogsAPIEntityResolverCachingTests {
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
+
         // Pre-populate cache
         await cache.set(value: "Cached Master Title", for: "discogs-master-11111", lifespan: 3600)
         mockCache.getCallCount = 0
-        
+
         // When
         let result = try await resolver.resolveMaster(id: 11111)
-        
+
         // Then
         #expect(result == "Cached Master Title")
         #expect(mockSession.requestCount == 0)
     }
-    
-    @Test("resolveMaster fetches from API and caches on miss")
+
+    @Test("resolveMaster fetches from backend proxy and caches on miss")
     func resolveMasterFetchesAndCaches() async throws {
         // Given
         let mockCache = EntityResolverMockCache()
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
-        // Mock API response
-        let masterResponse = """
+
+        // Mock backend proxy response
+        let proxyResponse = """
         {
-            "id": 77777,
-            "title": "New Master From API"
+            "name": "New Master From API",
+            "type": "master",
+            "id": 77777
         }
         """.data(using: .utf8)!
-        mockSession.responses["/masters/77777"] = masterResponse
-    
+        mockSession.responses["type=master&id=77777"] = proxyResponse
+
         // When
         let result = try await resolver.resolveMaster(id: 77777)
-        
+
         // Then
         #expect(result == "New Master From API")
         #expect(mockSession.requestCount == 1)
         #expect(mockCache.keysSet.contains("discogs-master-77777"))
     }
-    
+
     @Test("Second call returns cached result without additional API call")
     func secondCallReturnsCached() async throws {
         // Given
@@ -243,31 +248,32 @@ struct DiscogsAPIEntityResolverCachingTests {
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
-        // Mock API response
-        let artistResponse = """
+
+        // Mock backend proxy response
+        let proxyResponse = """
         {
-            "id": 33333,
-            "name": "Test Artist"
+            "name": "Test Artist",
+            "type": "artist",
+            "id": 33333
         }
         """.data(using: .utf8)!
-        mockSession.responses["/artists/33333"] = artistResponse
-        
+        mockSession.responses["type=artist&id=33333"] = proxyResponse
+
         // When - first call
         let result1 = try await resolver.resolveArtist(id: 33333)
         let firstCallCount = mockSession.requestCount
-        
+
         // When - second call
         let result2 = try await resolver.resolveArtist(id: 33333)
         let secondCallCount = mockSession.requestCount
-        
+
         // Then
         #expect(result1 == "Test Artist")
         #expect(result2 == "Test Artist")
         #expect(firstCallCount == 1)
         #expect(secondCallCount == 1, "Second call should use cache, not make another API call")
     }
-    
+
     @Test("Uses correct cache key format for each entity type")
     func usesCorrectCacheKeyFormat() async throws {
         // Given
@@ -275,12 +281,12 @@ struct DiscogsAPIEntityResolverCachingTests {
         let cache = CacheCoordinator(cache: mockCache)
         let mockSession = EntityResolverMockWebSession()
         let resolver = DiscogsAPIEntityResolver(session: mockSession, cache: cache)
-        
+
         // Mock responses
-        mockSession.responses["/artists/1"] = #"{"id": 1, "name": "A"}"#.data(using: .utf8)!
-        mockSession.responses["/releases/2"] = #"{"id": 2, "title": "R"}"#.data(using: .utf8)!
-        mockSession.responses["/masters/3"] = #"{"id": 3, "title": "M"}"#.data(using: .utf8)!
-        
+        mockSession.responses["type=artist&id=1"] = #"{"name": "A", "type": "artist", "id": 1}"#.data(using: .utf8)!
+        mockSession.responses["type=release&id=2"] = #"{"name": "R", "type": "release", "id": 2}"#.data(using: .utf8)!
+        mockSession.responses["type=master&id=3"] = #"{"name": "M", "type": "master", "id": 3}"#.data(using: .utf8)!
+
         // When
         _ = try await resolver.resolveArtist(id: 1)
         _ = try await resolver.resolveRelease(id: 2)


### PR DESCRIPTION
## Summary

- Add `SessionTokenProvider` protocol in Core for authenticated proxy API calls
- Rewrite `DiscogsArtworkService` to call `GET /proxy/artwork/search` via backend instead of Discogs API directly
- Rewrite `DiscogsAPIEntityResolver` to call `GET /proxy/entity/resolve` via backend instead of Discogs API directly
- Remove `Secrets` dependency from Artwork and Metadata packages
- Update entity resolver caching tests for new proxy response format

Closes #144

## Test plan

- [x] Entity resolver caching tests updated for new response format
- [ ] Build all targets (iOS, watchOS, tvOS, Share Extension, Widget)
- [ ] Verify artwork loads in playlist view
- [ ] Verify entity names resolve correctly in metadata enrichment
- [ ] Verify graceful degradation when backend is unreachable