### PR TITLE
Trim white borders from album artwork

### DIFF
--- a/Shared/Artwork/Sources/Artwork/CachingArtworkFetcher.swift
+++ b/Shared/Artwork/Sources/Artwork/CachingArtworkFetcher.swift
@@ -35,7 +35,8 @@ extension CacheCoordinator: ArtworkService {
     }
 
     func set(artwork: CGImage, for id: String, lifespan: TimeInterval) async {
-        let scaledArtwork = scaleCGImage(artwork, toWidth: ArtworkCacheConfiguration.targetWidth)
+        let trimmedArtwork = trimWhiteBorder(from: artwork)
+        let scaledArtwork = scaleCGImage(trimmedArtwork, toWidth: ArtworkCacheConfiguration.targetWidth)
         let artworkData = encodeCGImageAsHEIF(scaledArtwork, compressionQuality: ArtworkCacheConfiguration.heifCompressionQuality)
             ?? encodeCGImageAsPNG(scaledArtwork)
         self.setData(artworkData, for: id, lifespan: lifespan)

--- a/Shared/Artwork/Sources/Artwork/WhiteBorderTrimmer.swift
+++ b/Shared/Artwork/Sources/Artwork/WhiteBorderTrimmer.swift
@@ -1,0 +1,231 @@
+//
+//  WhiteBorderTrimmer.swift
+//  Artwork
+//
+//  Detects and crops thin white borders from album artwork images.
+//  Scans each edge inward, counting near-white pixels per scanline,
+//  and trims lines where 95%+ of pixels are near-white, up to 5% of the dimension.
+//
+//  Created by Jake Bromberg on 03/08/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import CoreGraphics
+
+// MARK: - Thresholds
+
+/// Minimum value (inclusive) for each R, G, B, A channel to qualify as "near-white."
+private let nearWhiteMin: UInt8 = 240
+
+/// Fraction of pixels in a scanline that must be near-white to count as border.
+private let scanlineConsensus: Double = 0.95
+
+/// Maximum fraction of a dimension that can be trimmed per edge.
+private let maxTrimFraction: Double = 0.05
+
+/// Minimum fraction of each original dimension that must remain after trimming.
+private let minRemainingFraction: Double = 0.50
+
+// MARK: - Public API
+
+/// Trims near-white borders from a CGImage.
+///
+/// Scans each edge (top, bottom, left, right) inward one scanline at a time.
+/// A scanline is considered "border" if 95%+ of its pixels have all RGB channels
+/// and alpha >= 240. Scanning stops at the first non-border scanline or when
+/// 5% of that dimension has been reached. Returns the original image if no
+/// trimming is needed or if trimming would reduce either dimension below 50%.
+///
+/// - Parameter image: The source image to trim.
+/// - Returns: A cropped image with white borders removed, or the original if no trimming is needed.
+func trimWhiteBorder(from image: CGImage) -> CGImage {
+    let width = image.width
+    let height = image.height
+
+    guard width > 0, height > 0 else { return image }
+
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+
+    guard let context = CGContext(
+        data: nil,
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bytesPerRow: bytesPerRow,
+        space: colorSpace,
+        bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+    ) else {
+        return image
+    }
+
+    context.draw(image, in: CGRect(x: 0, y: 0, width: width, height: height))
+
+    guard let data = context.data else { return image }
+
+    let pixels = data.assumingMemoryBound(to: UInt8.self)
+
+    // Safety valve: if the image is predominantly near-white, there's no
+    // content border to reveal, so return unchanged.
+    if isImageMostlyWhite(pixels: pixels, totalPixels: width * height) {
+        return image
+    }
+
+    let maxTrimH = max(1, Int(Double(height) * maxTrimFraction))
+    let maxTrimW = max(1, Int(Double(width) * maxTrimFraction))
+
+    let topTrim = scanEdge(pixels: pixels, width: width, height: height, edge: .top, maxTrim: maxTrimH)
+    let bottomTrim = scanEdge(pixels: pixels, width: width, height: height, edge: .bottom, maxTrim: maxTrimH)
+    let leftTrim = scanEdge(pixels: pixels, width: width, height: height, edge: .left, maxTrim: maxTrimW)
+    let rightTrim = scanEdge(pixels: pixels, width: width, height: height, edge: .right, maxTrim: maxTrimW)
+
+    guard topTrim > 0 || bottomTrim > 0 || leftTrim > 0 || rightTrim > 0 else {
+        return image
+    }
+
+    let newWidth = width - leftTrim - rightTrim
+    let newHeight = height - topTrim - bottomTrim
+
+    guard
+        newWidth >= Int(Double(width) * minRemainingFraction),
+        newHeight >= Int(Double(height) * minRemainingFraction)
+    else {
+        return image
+    }
+
+    // CGImage coordinate system: origin is top-left for cropping
+    let cropRect = CGRect(x: leftTrim, y: topTrim, width: newWidth, height: newHeight)
+
+    return image.cropping(to: cropRect) ?? image
+}
+
+// MARK: - Edge Scanning
+
+private enum Edge {
+    case top, bottom, left, right
+}
+
+/// Scans inward from the given edge, counting consecutive scanlines that are near-white.
+///
+/// - Parameters:
+///   - pixels: Pointer to RGBA pixel data.
+///   - width: Image width in pixels.
+///   - height: Image height in pixels.
+///   - edge: Which edge to scan from.
+///   - maxTrim: Maximum number of scanlines to trim.
+/// - Returns: Number of border scanlines detected.
+private func scanEdge(
+    pixels: UnsafePointer<UInt8>,
+    width: Int,
+    height: Int,
+    edge: Edge,
+    maxTrim: Int
+) -> Int {
+    let bytesPerPixel = 4
+    var trimCount = 0
+
+    switch edge {
+    case .top:
+        for row in 0..<min(maxTrim, height) {
+            if isScanlineNearWhite(pixels: pixels, start: row * width * bytesPerPixel, count: width, stride: bytesPerPixel) {
+                trimCount += 1
+            } else {
+                break
+            }
+        }
+
+    case .bottom:
+        for i in 0..<min(maxTrim, height) {
+            let row = height - 1 - i
+            if isScanlineNearWhite(pixels: pixels, start: row * width * bytesPerPixel, count: width, stride: bytesPerPixel) {
+                trimCount += 1
+            } else {
+                break
+            }
+        }
+
+    case .left:
+        for col in 0..<min(maxTrim, width) {
+            if isColumnNearWhite(pixels: pixels, col: col, width: width, height: height, bytesPerPixel: bytesPerPixel) {
+                trimCount += 1
+            } else {
+                break
+            }
+        }
+
+    case .right:
+        for i in 0..<min(maxTrim, width) {
+            let col = width - 1 - i
+            if isColumnNearWhite(pixels: pixels, col: col, width: width, height: height, bytesPerPixel: bytesPerPixel) {
+                trimCount += 1
+            } else {
+                break
+            }
+        }
+    }
+
+    return trimCount
+}
+
+// MARK: - Pixel Analysis
+
+/// Checks whether a horizontal scanline has >= 95% near-white pixels.
+private func isScanlineNearWhite(
+    pixels: UnsafePointer<UInt8>,
+    start: Int,
+    count: Int,
+    stride: Int
+) -> Bool {
+    var whiteCount = 0
+
+    for i in 0..<count {
+        let offset = start + i * stride
+        if isNearWhite(r: pixels[offset], g: pixels[offset + 1], b: pixels[offset + 2], a: pixels[offset + 3]) {
+            whiteCount += 1
+        }
+    }
+
+    return Double(whiteCount) / Double(count) >= scanlineConsensus
+}
+
+/// Checks whether a vertical column has >= 95% near-white pixels.
+private func isColumnNearWhite(
+    pixels: UnsafePointer<UInt8>,
+    col: Int,
+    width: Int,
+    height: Int,
+    bytesPerPixel: Int
+) -> Bool {
+    var whiteCount = 0
+
+    for row in 0..<height {
+        let offset = (row * width + col) * bytesPerPixel
+        if isNearWhite(r: pixels[offset], g: pixels[offset + 1], b: pixels[offset + 2], a: pixels[offset + 3]) {
+            whiteCount += 1
+        }
+    }
+
+    return Double(whiteCount) / Double(height) >= scanlineConsensus
+}
+
+/// Returns true if 95%+ of all pixels in the image are near-white.
+/// Used as a safety valve to avoid trimming images with no meaningful content border.
+private func isImageMostlyWhite(pixels: UnsafePointer<UInt8>, totalPixels: Int) -> Bool {
+    let bytesPerPixel = 4
+    var whiteCount = 0
+
+    for i in 0..<totalPixels {
+        let offset = i * bytesPerPixel
+        if isNearWhite(r: pixels[offset], g: pixels[offset + 1], b: pixels[offset + 2], a: pixels[offset + 3]) {
+            whiteCount += 1
+        }
+    }
+
+    return Double(whiteCount) / Double(totalPixels) >= scanlineConsensus
+}
+
+/// Returns true if a pixel's RGBA channels are all >= 240.
+private func isNearWhite(r: UInt8, g: UInt8, b: UInt8, a: UInt8) -> Bool {
+    r >= nearWhiteMin && g >= nearWhiteMin && b >= nearWhiteMin && a >= nearWhiteMin
+}

--- a/Shared/Artwork/Tests/ArtworkTests/WhiteBorderTrimmerTests.swift
+++ b/Shared/Artwork/Tests/ArtworkTests/WhiteBorderTrimmerTests.swift
@@ -1,0 +1,316 @@
+//
+//  WhiteBorderTrimmerTests.swift
+//  ArtworkTests
+//
+//  Tests for white border detection and trimming of album artwork images.
+//
+//  Created by Jake Bromberg on 03/08/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import CoreGraphics
+import Foundation
+@testable import Artwork
+
+@Suite("White Border Trimmer Tests")
+struct WhiteBorderTrimmerTests {
+
+    @Test("No border - solid color image is unchanged")
+    func noBorder() {
+        let image = createBorderedImage(
+            size: CGSize(width: 100, height: 100),
+            borderColor: .blue,
+            contentColor: .blue,
+            top: 0, bottom: 0, left: 0, right: 0
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Uniform 5px white border is trimmed")
+    func uniformWhiteBorder() {
+        let image = createBorderedImage(
+            size: CGSize(width: 110, height: 110),
+            borderColor: .white,
+            contentColor: .blue,
+            top: 5, bottom: 5, left: 5, right: 5
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Top border only is trimmed")
+    func topBorderOnly() {
+        let image = createBorderedImage(
+            size: CGSize(width: 100, height: 104),
+            borderColor: .white,
+            contentColor: .blue,
+            top: 4, bottom: 0, left: 0, right: 0
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Left and right borders only are trimmed")
+    func leftRightBordersOnly() {
+        let image = createBorderedImage(
+            size: CGSize(width: 106, height: 100),
+            borderColor: .white,
+            contentColor: .blue,
+            top: 0, bottom: 0, left: 3, right: 3
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Near-white JPEG artifact border is trimmed")
+    func nearWhiteJPEGArtifacts() {
+        let nearWhite = TestColor(r: 245, g: 248, b: 242, a: 255)
+        let image = createBorderedImage(
+            size: CGSize(width: 110, height: 110),
+            borderColor: nearWhite,
+            contentColor: .blue,
+            top: 5, bottom: 5, left: 5, right: 5
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Light gray border below threshold is not trimmed")
+    func lightGrayBorderNotTrimmed() {
+        let lightGray = TestColor(r: 200, g: 200, b: 200, a: 255)
+        let image = createBorderedImage(
+            size: CGSize(width: 110, height: 110),
+            borderColor: lightGray,
+            contentColor: .blue,
+            top: 5, bottom: 5, left: 5, right: 5
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 110)
+        #expect(result.height == 110)
+    }
+
+    @Test("Trim capped at 5% of dimension")
+    func capAt5Percent() {
+        // 200x200 image with 15px white border (7.5% of dimension)
+        // Should cap trim at 10px per side (5%)
+        let image = createBorderedImage(
+            size: CGSize(width: 200, height: 200),
+            borderColor: .white,
+            contentColor: .blue,
+            top: 15, bottom: 15, left: 15, right: 15
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 180)
+        #expect(result.height == 180)
+    }
+
+    @Test("Non-square image with border")
+    func nonSquareImage() {
+        let image = createBorderedImage(
+            size: CGSize(width: 200, height: 100),
+            borderColor: .white,
+            contentColor: .blue,
+            top: 3, bottom: 3, left: 3, right: 3
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 194)
+        #expect(result.height == 94)
+    }
+
+    @Test("All-white image is unchanged (safety valve)")
+    func allWhiteImageUnchanged() {
+        let image = createBorderedImage(
+            size: CGSize(width: 100, height: 100),
+            borderColor: .white,
+            contentColor: .white,
+            top: 0, bottom: 0, left: 0, right: 0
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 100)
+        #expect(result.height == 100)
+    }
+
+    @Test("Noisy border row at 95% threshold is trimmed")
+    func noisyBorderAtThreshold() {
+        // Create a 100x10 image where first row has 95 white + 5 blue pixels
+        let image = createImageWithNoisyBorder(
+            width: 100, height: 10,
+            whitePixelsInBorderRow: 95,
+            borderRows: 1
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        // The first row should be trimmed (95% white meets the threshold)
+        #expect(result.height == 9)
+    }
+
+    @Test("Noisy border row below 95% threshold is not trimmed")
+    func noisyBorderBelowThreshold() {
+        // Create a 100x10 image where first row has 90 white + 10 blue pixels
+        let image = createImageWithNoisyBorder(
+            width: 100, height: 10,
+            whitePixelsInBorderRow: 90,
+            borderRows: 1
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        // The row should NOT be trimmed (90% white is below threshold)
+        #expect(result.height == 10)
+    }
+
+    @Test("Transparent white border is not trimmed")
+    func transparentWhiteBorderNotTrimmed() {
+        let transparentWhite = TestColor(r: 255, g: 255, b: 255, a: 128)
+        let image = createBorderedImage(
+            size: CGSize(width: 110, height: 110),
+            borderColor: transparentWhite,
+            contentColor: .blue,
+            top: 5, bottom: 5, left: 5, right: 5
+        )
+
+        let result = trimWhiteBorder(from: image)
+
+        #expect(result.width == 110)
+        #expect(result.height == 110)
+    }
+}
+
+// MARK: - Test Helpers
+
+struct TestColor {
+    let r: UInt8
+    let g: UInt8
+    let b: UInt8
+    let a: UInt8
+
+    static let white = TestColor(r: 255, g: 255, b: 255, a: 255)
+    static let blue = TestColor(r: 0, g: 0, b: 255, a: 255)
+}
+
+/// Creates a CGImage with a colored border around a colored content area.
+///
+/// The total image size is `size`. The border is drawn in `borderColor` with the specified
+/// thicknesses, and the remaining interior is filled with `contentColor`.
+func createBorderedImage(
+    size: CGSize,
+    borderColor: TestColor,
+    contentColor: TestColor,
+    top: Int,
+    bottom: Int,
+    left: Int,
+    right: Int
+) -> CGImage {
+    let width = Int(size.width)
+    let height = Int(size.height)
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+
+    for y in 0..<height {
+        for x in 0..<width {
+            let offset = (y * width + x) * bytesPerPixel
+            let isBorder = y < top || y >= height - bottom || x < left || x >= width - right
+            let color = isBorder ? borderColor : contentColor
+            pixels[offset] = color.r
+            pixels[offset + 1] = color.g
+            pixels[offset + 2] = color.b
+            pixels[offset + 3] = color.a
+        }
+    }
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let data = Data(pixels)
+    let provider = CGDataProvider(data: data as CFData)!
+
+    return CGImage(
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bitsPerPixel: 32,
+        bytesPerRow: bytesPerRow,
+        space: colorSpace,
+        bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+        provider: provider,
+        decode: nil,
+        shouldInterpolate: false,
+        intent: .defaultIntent
+    )!
+}
+
+/// Creates an image with a "noisy" top border for threshold testing.
+///
+/// The first `borderRows` rows contain `whitePixelsInBorderRow` white pixels followed
+/// by blue pixels. All remaining rows are solid blue.
+func createImageWithNoisyBorder(
+    width: Int,
+    height: Int,
+    whitePixelsInBorderRow: Int,
+    borderRows: Int
+) -> CGImage {
+    let bytesPerPixel = 4
+    let bytesPerRow = width * bytesPerPixel
+    var pixels = [UInt8](repeating: 0, count: width * height * bytesPerPixel)
+
+    for y in 0..<height {
+        for x in 0..<width {
+            let offset = (y * width + x) * bytesPerPixel
+            let isWhite = y < borderRows && x < whitePixelsInBorderRow
+            if isWhite {
+                pixels[offset] = 255     // R
+                pixels[offset + 1] = 255 // G
+                pixels[offset + 2] = 255 // B
+                pixels[offset + 3] = 255 // A
+            } else {
+                pixels[offset] = 0       // R
+                pixels[offset + 1] = 0   // G
+                pixels[offset + 2] = 255 // B
+                pixels[offset + 3] = 255 // A
+            }
+        }
+    }
+
+    let colorSpace = CGColorSpaceCreateDeviceRGB()
+    let data = Data(pixels)
+    let provider = CGDataProvider(data: data as CFData)!
+
+    return CGImage(
+        width: width,
+        height: height,
+        bitsPerComponent: 8,
+        bitsPerPixel: 32,
+        bytesPerRow: bytesPerRow,
+        space: colorSpace,
+        bitmapInfo: CGBitmapInfo(rawValue: CGImageAlphaInfo.premultipliedLast.rawValue),
+        provider: provider,
+        decode: nil,
+        shouldInterpolate: false,
+        intent: .defaultIntent
+    )!
+}


### PR DESCRIPTION
## Summary

- Add `trimWhiteBorder(from:)` in the Artwork package to detect and crop thin white scan borders from album art before caching
- Integrates as a single-line call in `CachingArtworkFetcher.set(artwork:for:lifespan:)`, running on the full-resolution source before scaling
- Includes a safety valve that skips predominantly white images to avoid trimming all-white artwork

Closes #150

## Test plan

- [x] 12 unit tests covering all edge cases (uniform border, single-edge, near-white JPEG artifacts, threshold boundaries, 5% cap, non-square images, all-white safety valve, transparent borders)
- [ ] Manual: browse playlist in app and verify Discogs-sourced artwork no longer shows white strips at rounded corners