### PR TITLE
Add HLSPlayerModule with time-shifted HLS playback

### DIFF
--- a/Shared/Core/Sources/Core/Models and Services/RadioStation.swift
+++ b/Shared/Core/Sources/Core/Models and Services/RadioStation.swift
@@ -15,6 +15,7 @@ public struct RadioStation: Sendable {
     public let description: String
     public let requestLine: URL
     public let streamURL: URL
+    public let hlsStreamURL: URL
     public let merchURL: URL
 }
 
@@ -24,6 +25,7 @@ public extension RadioStation {
         description: "WXYC 89.3 FM is the non-commercial student-run radio station of the University of North Carolina at Chapel Hill. We broadcast at 1100 watts from the student union on the UNC campus, 24 hours a day, 365 days a year. Our coverage area encompasses approximately 900 square miles in and around Chapel Hill, Durham, Pittsboro, Apex, and parts of Raleigh.",
         requestLine: URL(string: "tel://9199628989")!,
         streamURL: URL(string: "https://audio-mp3.ibiblio.org/wxyc.mp3")!,
+        hlsStreamURL: URL(string: "https://hls.wxyc.org/live/live.m3u8")!,
         merchURL: URL(string: "https://merch.wxyc.org")!
     )
 }

--- a/Shared/Playback/Package.swift
+++ b/Shared/Playback/Package.swift
@@ -53,15 +53,28 @@ let package = Package(
             path: "Sources/MP3Streamer"
         ),
 
+        // AVPlayer-based HLS player with seeking (iOS/macOS/tvOS only, not watchOS)
+        .target(
+            name: "HLSPlayerModule",
+            dependencies: [
+                "PlaybackCore",
+                "Core",
+                "Analytics",
+                "Logger",
+            ],
+            path: "Sources/HLSPlayer"
+        ),
+
         // MARK: - Public-Facing Targets
 
-        // iOS/macOS/tvOS playback (includes both players)
+        // iOS/macOS/tvOS playback (includes all players)
         .target(
             name: "Playback",
             dependencies: [
                 "PlaybackCore",
                 "RadioPlayerModule",
                 "MP3StreamerModule",
+                "HLSPlayerModule",
                 "Logger",
             ],
             path: "Sources/PlaybackAPI"
@@ -85,6 +98,7 @@ let package = Package(
                 "PlaybackCore",
                 "RadioPlayerModule",
                 "MP3StreamerModule",
+                "HLSPlayerModule",
                 .product(name: "AnalyticsTesting", package: "Analytics"),
             ],
             path: "Tests/PlaybackTestUtilities",
@@ -106,6 +120,16 @@ let package = Package(
             name: "MP3StreamerTests",
             dependencies: ["MP3StreamerModule", "PlaybackCore", "Core", "PlaybackTestUtilities", .product(name: "AnalyticsTesting", package: "Analytics")],
             resources: [.process("Resources")]
+        ),
+        .testTarget(
+            name: "HLSPlayerTests",
+            dependencies: [
+                "HLSPlayerModule",
+                "PlaybackCore",
+                "Core",
+                "PlaybackTestUtilities",
+                .product(name: "AnalyticsTesting", package: "Analytics"),
+            ]
         ),
     ]
 )

--- a/Shared/Playback/Sources/HLSPlayer/HLSPlayer.swift
+++ b/Shared/Playback/Sources/HLSPlayer/HLSPlayer.swift
@@ -1,0 +1,257 @@
+//
+//  HLSPlayer.swift
+//  HLSPlayerModule
+//
+//  AVPlayer-based HLS streaming player with time-shifting support.
+//  Conforms to both AudioPlayerProtocol and TimeShiftablePlayer, enabling
+//  listeners to seek backwards within a live HLS stream.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import CoreMedia
+import Logger
+import Core
+import Analytics
+import PlaybackCore
+
+/// The number of seconds within which the player is considered "at the live edge."
+/// Two HLS segments at 6 seconds each = 12 seconds.
+private let liveEdgeThresholdSeconds: TimeInterval = 12
+
+/// The maximum lookback window in seconds (1 hour).
+private let maxLookbackCap: TimeInterval = 3600
+
+/// The interval between time position stream updates.
+private let timePositionUpdateInterval: Duration = .milliseconds(500)
+
+@MainActor
+@Observable
+public final class HLSPlayer: Sendable {
+    private let player: any HLSAVPlayerProtocol
+    private let analytics: AnalyticsService?
+    private let notificationCenter: NotificationCenter
+    private var rateObservation: (any NSObjectProtocol)?
+    private var stallObservation: (any NSObjectProtocol)?
+    private var failureObservation: (any NSObjectProtocol)?
+    private var timePositionTask: Task<Void, Never>?
+
+    // MARK: - State
+
+    public private(set) var state: PlayerState = .idle {
+        didSet {
+            if state != oldValue {
+                stateContinuation.yield(state)
+                if state == .playing {
+                    startTimePositionUpdates()
+                } else if state == .idle {
+                    stopTimePositionUpdates()
+                }
+            }
+        }
+    }
+
+    public var isPlaying: Bool { state == .playing }
+
+    // MARK: - Time-Shift State
+
+    public private(set) var secondsBehindLive: TimeInterval = 0
+
+    public var isAtLiveEdge: Bool {
+        secondsBehindLive < liveEdgeThresholdSeconds
+    }
+
+    public var maxLookbackSeconds: TimeInterval {
+        guard let range = primarySeekableRange else { return 0 }
+        return min(range.duration.seconds, maxLookbackCap)
+    }
+
+    // MARK: - Streams
+
+    public let stateStream: AsyncStream<PlayerState>
+    private let stateContinuation: AsyncStream<PlayerState>.Continuation
+
+    public let audioBufferStream: AsyncStream<AVAudioPCMBuffer>
+
+    public let eventStream: AsyncStream<AudioPlayerInternalEvent>
+    private let eventContinuation: AsyncStream<AudioPlayerInternalEvent>.Continuation
+
+    public let timePositionStream: AsyncStream<TimeInterval>
+    private let timePositionContinuation: AsyncStream<TimeInterval>.Continuation
+
+    // MARK: - Initialization
+
+    public convenience init(url: URL) {
+        self.init(
+            player: AVPlayerHLSAdapter(url: url),
+            analytics: StructuredPostHogAnalytics.shared,
+            notificationCenter: .default
+        )
+    }
+
+    init(
+        player: any HLSAVPlayerProtocol,
+        analytics: AnalyticsService? = nil,
+        notificationCenter: NotificationCenter = .default
+    ) {
+        self.player = player
+        self.analytics = analytics
+        self.notificationCenter = notificationCenter
+
+        var stateContinuation: AsyncStream<PlayerState>.Continuation!
+        self.stateStream = AsyncStream { continuation in
+            stateContinuation = continuation
+        }
+        self.stateContinuation = stateContinuation
+
+        self.audioBufferStream = AsyncStream { continuation in
+            continuation.finish()
+        }
+
+        var eventContinuation: AsyncStream<AudioPlayerInternalEvent>.Continuation!
+        self.eventStream = AsyncStream { continuation in
+            eventContinuation = continuation
+        }
+        self.eventContinuation = eventContinuation
+
+        var timePositionContinuation: AsyncStream<TimeInterval>.Continuation!
+        self.timePositionStream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { continuation in
+            timePositionContinuation = continuation
+        }
+        self.timePositionContinuation = timePositionContinuation
+
+        self.rateObservation = notificationCenter.addMainActorObserver(
+            of: player as? AVPlayer,
+            for: HLSRateDidChangeMessage.self
+        ) { [weak self] message in
+            guard let self else { return }
+            Log(.info, category: .playback, "HLSPlayer did receive rate change: \(message.rate)")
+            self.handleRateChange(rate: message.rate)
+        }
+
+        self.stallObservation = notificationCenter.addMainActorObserver(
+            for: HLSPlaybackStalledMessage.self
+        ) { [weak self] _ in
+            guard let self else { return }
+            Log(.error, category: .playback, "HLSPlayer playback stalled")
+            self.handlePlaybackStalled()
+        }
+
+        self.failureObservation = notificationCenter.addMainActorObserver(
+            for: HLSFailedToPlayToEndMessage.self
+        ) { [weak self] message in
+            guard let self else { return }
+            Log(.error, category: .playback, "HLSPlayer failed to play to end: \(String(describing: message.error))")
+            self.handleFailure(message.error)
+        }
+    }
+
+    // MARK: - Playback Control
+
+    public func play() {
+        if state == .playing {
+            analytics?.capture(PlaybackStartedEvent(reason: "already playing (hls)"))
+            return
+        }
+
+        analytics?.capture(PlaybackStartedEvent(reason: "hlsPlayer play"))
+        state = .loading
+        player.play()
+    }
+
+    public func stop() {
+        stopTimePositionUpdates()
+        state = .idle
+        player.pause()
+    }
+
+    // MARK: - Seeking
+
+    public func seek(secondsBehindLive offset: TimeInterval) async {
+        guard let range = primarySeekableRange else { return }
+        let liveEdge = range.start + range.duration
+        let clampedOffset = min(max(0, offset), maxLookbackSeconds)
+        let targetTime = CMTime(
+            seconds: liveEdge.seconds - clampedOffset,
+            preferredTimescale: 600
+        )
+        let _ = await player.seek(to: targetTime)
+        updateTimePosition()
+    }
+
+    public func seekToLive() async {
+        await seek(secondsBehindLive: 0)
+    }
+
+    // MARK: - Render Tap (No-op)
+
+    public func installRenderTap() {}
+    public func removeRenderTap() {}
+
+    // MARK: - Private
+
+    private var primarySeekableRange: CMTimeRange? {
+        player.seekableTimeRanges.first.map { $0.timeRangeValue }
+    }
+
+    private func handleRateChange(rate: Float) {
+        if rate > 0 {
+            if state == .loading || state == .stalled {
+                if state == .stalled {
+                    eventContinuation.yield(.recovery)
+                }
+                state = .playing
+            }
+        }
+    }
+
+    private func handlePlaybackStalled() {
+        if state == .playing || state == .loading {
+            state = .stalled
+            eventContinuation.yield(.stall)
+        }
+    }
+
+    private func handleFailure(_ error: (any Error)?) {
+        let playbackError = PlaybackError.connectionFailed(
+            error?.localizedDescription ?? "HLS playback failed"
+        )
+        state = .error(playbackError)
+        eventContinuation.yield(.error(error ?? playbackError))
+    }
+
+    private func updateTimePosition() {
+        guard let range = primarySeekableRange else {
+            secondsBehindLive = 0
+            return
+        }
+        let liveEdge = range.start + range.duration
+        let current = player.currentTime()
+        secondsBehindLive = max(0, liveEdge.seconds - current.seconds)
+        timePositionContinuation.yield(secondsBehindLive)
+    }
+
+    private func startTimePositionUpdates() {
+        guard timePositionTask == nil else { return }
+        timePositionTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(for: timePositionUpdateInterval)
+                guard let self, self.state == .playing else { break }
+                self.updateTimePosition()
+            }
+        }
+    }
+
+    private func stopTimePositionUpdates() {
+        timePositionTask?.cancel()
+        timePositionTask = nil
+    }
+}
+
+// MARK: - AudioPlayerProtocol + TimeShiftablePlayer
+
+extension HLSPlayer: AudioPlayerProtocol {}
+extension HLSPlayer: TimeShiftablePlayer {}

--- a/Shared/Playback/Sources/HLSPlayer/Messages/HLSPlayerMessages.swift
+++ b/Shared/Playback/Sources/HLSPlayer/Messages/HLSPlayerMessages.swift
@@ -1,0 +1,93 @@
+//
+//  HLSPlayerMessages.swift
+//  HLSPlayerModule
+//
+//  MainActorNotificationMessage types for HLSPlayer's notification handling.
+//  Mirrors the message types in RadioPlayerModule for the same AVPlayer notifications.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import Core
+
+// MARK: - Rate Change Message
+
+/// Message for AVPlayer rate changes, indicating playback state transitions.
+struct HLSRateDidChangeMessage: MainActorNotificationMessage {
+    typealias Subject = AVPlayer
+
+    static var name: Notification.Name {
+        AVPlayer.rateDidChangeNotification
+    }
+
+    let rate: Float
+
+    static func makeMessage(_ notification: sending Notification) -> Self? {
+        if let player = notification.object as? AVPlayer {
+            return Self(rate: player.rate)
+        }
+        if let rate = notification.userInfo?["rate"] as? Float {
+            return Self(rate: rate)
+        }
+        return Self(rate: 0)
+    }
+
+    @MainActor
+    static func makeNotification(_ message: Self, object: AVPlayer?) -> Notification {
+        Notification(
+            name: name,
+            object: object,
+            userInfo: ["rate": message.rate]
+        )
+    }
+}
+
+// MARK: - Playback Stalled Message
+
+/// Message for AVPlayerItem playback stalls.
+struct HLSPlaybackStalledMessage: MainActorNotificationMessage {
+    typealias Subject = AVPlayerItem
+
+    static var name: Notification.Name {
+        .AVPlayerItemPlaybackStalled
+    }
+
+    static func makeMessage(_ notification: sending Notification) -> Self? {
+        Self()
+    }
+
+    @MainActor
+    static func makeNotification(_ message: Self, object: AVPlayerItem?) -> Notification {
+        Notification(name: name, object: object)
+    }
+}
+
+// MARK: - Failed to Play to End Message
+
+/// Message for AVPlayerItem failure to play to end.
+struct HLSFailedToPlayToEndMessage: MainActorNotificationMessage {
+    typealias Subject = AVPlayerItem
+
+    static var name: Notification.Name {
+        .AVPlayerItemFailedToPlayToEndTime
+    }
+
+    let error: (any Error)?
+
+    static func makeMessage(_ notification: sending Notification) -> Self? {
+        let error = notification.userInfo?[AVPlayerItemFailedToPlayToEndTimeErrorKey] as? any Error
+        return Self(error: error)
+    }
+
+    @MainActor
+    static func makeNotification(_ message: Self, object: AVPlayerItem?) -> Notification {
+        var userInfo: [String: Any]?
+        if let error = message.error {
+            userInfo = [AVPlayerItemFailedToPlayToEndTimeErrorKey: error]
+        }
+        return Notification(name: name, object: object, userInfo: userInfo)
+    }
+}

--- a/Shared/Playback/Sources/HLSPlayer/Protocol/HLSAVPlayerProtocol.swift
+++ b/Shared/Playback/Sources/HLSPlayer/Protocol/HLSAVPlayerProtocol.swift
@@ -1,0 +1,62 @@
+//
+//  HLSAVPlayerProtocol.swift
+//  HLSPlayerModule
+//
+//  Abstraction over AVPlayer for HLS playback, enabling dependency injection and testability.
+//  The real implementation wraps AVPlayer; tests use MockHLSAVPlayer.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import AVFoundation
+import CoreMedia
+
+/// Abstraction over AVPlayer for HLS playback operations.
+///
+/// Provides the subset of AVPlayer + AVPlayerItem functionality needed by `HLSPlayer`:
+/// time queries, seekable range access, and seeking. State changes are observed via
+/// `NotificationCenter` (same pattern as `RadioPlayer`).
+@MainActor
+public protocol HLSAVPlayerProtocol: Sendable {
+    var rate: Float { get }
+    func play()
+    func pause()
+    func currentTime() -> CMTime
+    var seekableTimeRanges: [NSValue] { get }
+    func seek(to time: CMTime) async -> Bool
+}
+
+// MARK: - AVPlayer Adapter
+
+/// Wraps a real `AVPlayer` to conform to `HLSAVPlayerProtocol`.
+///
+/// Bridges `seekableTimeRanges` and `seek(to:)` through the player's current item.
+@MainActor
+final class AVPlayerHLSAdapter: HLSAVPlayerProtocol, @unchecked Sendable {
+    private let player: AVPlayer
+
+    init(url: URL) {
+        self.player = AVPlayer(playerItem: AVPlayerItem(url: url))
+    }
+
+    var rate: Float { player.rate }
+
+    func play() { player.play() }
+
+    func pause() { player.pause() }
+
+    func currentTime() -> CMTime { player.currentTime() }
+
+    var seekableTimeRanges: [NSValue] {
+        player.currentItem?.seekableTimeRanges ?? []
+    }
+
+    func seek(to time: CMTime) async -> Bool {
+        await withCheckedContinuation { continuation in
+            player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero) { finished in
+                continuation.resume(returning: finished)
+            }
+        }
+    }
+}

--- a/Shared/Playback/Sources/PlaybackCore/PlayerControllerType.swift
+++ b/Shared/Playback/Sources/PlaybackCore/PlayerControllerType.swift
@@ -16,6 +16,7 @@ import Foundation
 public enum PlayerControllerType: String, CaseIterable, Identifiable, Hashable, Sendable {
     case radioPlayer = "RadioPlayer"
     case mp3Streamer = "MP3Streamer"
+    case hlsPlayer = "HLSPlayer"
 
     // MARK: - Persistence
 

--- a/Shared/Playback/Sources/PlaybackCore/Protocols/TimeShiftablePlayer.swift
+++ b/Shared/Playback/Sources/PlaybackCore/Protocols/TimeShiftablePlayer.swift
@@ -1,0 +1,49 @@
+//
+//  TimeShiftablePlayer.swift
+//  PlaybackCore
+//
+//  Protocol for audio players that support time-shifting (seeking within a live stream).
+//  Extends AudioPlayerProtocol to add seek and time position capabilities.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// A player that supports time-shifting within a live stream.
+///
+/// Extends `AudioPlayerProtocol` with seeking capabilities, allowing listeners
+/// to scrub backwards from the live edge. Players that don't support time-shifting
+/// (like `RadioPlayer` and `MP3Streamer`) are unaffected -- controllers use
+/// `as? TimeShiftablePlayer` for optional capability discovery.
+@MainActor
+public protocol TimeShiftablePlayer: AudioPlayerProtocol {
+    /// Whether the player is currently at or near the live edge.
+    ///
+    /// Returns `true` when the current playback position is within 12 seconds
+    /// (approximately 2 HLS segments) of the live edge.
+    var isAtLiveEdge: Bool { get }
+
+    /// The number of seconds the current playback position is behind the live edge.
+    var secondsBehindLive: TimeInterval { get }
+
+    /// The maximum number of seconds the player can seek backwards from the live edge.
+    ///
+    /// Derived from the HLS playlist's seekable time range, capped at 3600 seconds (1 hour).
+    var maxLookbackSeconds: TimeInterval { get }
+
+    /// A stream of periodic time position updates (every 0.5 seconds).
+    ///
+    /// Yields the current `secondsBehindLive` value at each interval.
+    var timePositionStream: AsyncStream<TimeInterval> { get }
+
+    /// Seek to a position relative to the live edge.
+    ///
+    /// - Parameter secondsBehindLive: The desired offset in seconds behind the live edge.
+    ///   A value of 0 seeks to the live edge. Values are clamped to `maxLookbackSeconds`.
+    func seek(secondsBehindLive: TimeInterval) async
+
+    /// Seek to the live edge of the stream.
+    func seekToLive() async
+}

--- a/Shared/Playback/Tests/HLSPlayerTests/HLSPlayerTests.swift
+++ b/Shared/Playback/Tests/HLSPlayerTests/HLSPlayerTests.swift
@@ -1,0 +1,482 @@
+//
+//  HLSPlayerTests.swift
+//  HLSPlayerTests
+//
+//  Tests for HLSPlayer: state transitions, time-shift calculations, and seeking.
+//  Uses MockHLSAVPlayer and NotificationCenter for isolated, deterministic tests.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import AVFoundation
+import CoreMedia
+import Analytics
+import AnalyticsTesting
+@testable import HLSPlayerModule
+@testable import PlaybackCore
+
+@Suite("HLSPlayer Tests", .serialized)
+@MainActor
+struct HLSPlayerTests {
+
+    // MARK: - Initialization
+
+    @Test("Initializes in idle state")
+    func initializesIdle() {
+        let (player, _, _) = makePlayer()
+
+        #expect(player.state == .idle)
+        #expect(player.isPlaying == false)
+        #expect(player.isAtLiveEdge == true)
+        #expect(player.secondsBehindLive == 0)
+    }
+
+    // MARK: - Play / Stop
+
+    @Test("Play transitions to loading and calls underlying player")
+    func playTransitionsToLoading() {
+        let (player, mock, _) = makePlayer()
+
+        player.play()
+
+        #expect(player.state == .loading)
+        #expect(mock.playCallCount == 1)
+    }
+
+    @Test("Play when already playing does not call underlying player again")
+    func playWhenAlreadyPlaying() async throws {
+        let (player, mock, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        #expect(player.state == .playing)
+
+        mock.playCallCount = 0
+        player.play()
+
+        #expect(mock.playCallCount == 0)
+    }
+
+    @Test("Stop transitions to idle and pauses underlying player")
+    func stopTransitionsToIdle() async throws {
+        let (player, mock, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        #expect(player.state == .playing)
+
+        player.stop()
+
+        #expect(player.state == .idle)
+        #expect(mock.pauseCallCount == 1)
+    }
+
+    // MARK: - State Transitions via Notifications
+
+    @Test("Rate change notification transitions from loading to playing")
+    func rateChangeFromLoadingToPlaying() {
+        let (player, _, nc) = makePlayer()
+
+        player.play()
+        #expect(player.state == .loading)
+
+        simulateRateChange(rate: 1.0, on: nc)
+        #expect(player.state == .playing)
+    }
+
+    @Test("Stall notification transitions from playing to stalled")
+    func stallFromPlaying() {
+        let (player, _, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        #expect(player.state == .playing)
+
+        simulateStall(on: nc)
+        #expect(player.state == .stalled)
+    }
+
+    @Test("Rate change after stall transitions to playing (recovery)")
+    func recoveryFromStall() {
+        let (player, _, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        simulateStall(on: nc)
+        #expect(player.state == .stalled)
+
+        simulateRateChange(rate: 1.0, on: nc)
+        #expect(player.state == .playing)
+    }
+
+    @Test("Failure notification transitions to error state")
+    func failureTransitionsToError() {
+        let (player, _, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        simulateFailure(on: nc)
+        if case .error = player.state {
+            // Expected
+        } else {
+            Issue.record("Expected error state, got \(player.state)")
+        }
+    }
+
+    // MARK: - State Stream
+
+    @Test("State stream emits state transitions")
+    func stateStreamEmitsTransitions() async throws {
+        let (player, _, nc) = makePlayer()
+        var emitted: [PlayerState] = []
+
+        let task = Task {
+            for await state in player.stateStream {
+                emitted.append(state)
+                if emitted.count >= 3 { break }
+            }
+        }
+
+        // Give the iterator time to start
+        try await Task.sleep(for: .milliseconds(50))
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        player.stop()
+
+        await withTaskCancellation(of: task, after: .seconds(2))
+
+        #expect(emitted.contains(.loading))
+        #expect(emitted.contains(.playing))
+        #expect(emitted.contains(.idle))
+    }
+
+    // MARK: - Audio Buffer Stream
+
+    @Test("Audio buffer stream finishes immediately")
+    func audioBufferStreamFinishesImmediately() async {
+        let (player, _, _) = makePlayer()
+        var count = 0
+
+        for await _ in player.audioBufferStream {
+            count += 1
+        }
+
+        #expect(count == 0)
+    }
+
+    // MARK: - isAtLiveEdge
+
+    @Test(
+        "isAtLiveEdge is true when within threshold",
+        arguments: [0.0, 5.0, 11.9]
+    )
+    func isAtLiveEdgeWhenWithinThreshold(secondsBehind: TimeInterval) async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+        mock.setCurrentTimeBehindLive(secondsBehind)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        // Trigger a time position update by seeking
+        await player.seekToLive()
+        mock.setCurrentTimeBehindLive(secondsBehind)
+        await player.seek(secondsBehindLive: secondsBehind)
+
+        #expect(player.isAtLiveEdge == true)
+    }
+
+    @Test(
+        "isAtLiveEdge is false when beyond threshold",
+        arguments: [12.0, 30.0, 600.0, 3600.0]
+    )
+    func isAtLiveEdgeWhenBeyondThreshold(secondsBehind: TimeInterval) async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seek(secondsBehindLive: secondsBehind)
+
+        #expect(player.isAtLiveEdge == false)
+    }
+
+    // MARK: - secondsBehindLive
+
+    @Test("secondsBehindLive reflects current position after seek")
+    func secondsBehindLiveAfterSeek() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seek(secondsBehindLive: 120)
+
+        #expect(abs(player.secondsBehindLive - 120) < 0.1)
+    }
+
+    @Test("secondsBehindLive is zero at live edge")
+    func secondsBehindLiveAtLiveEdge() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seekToLive()
+
+        #expect(player.secondsBehindLive < 0.1)
+    }
+
+    // MARK: - maxLookbackSeconds
+
+    @Test("maxLookbackSeconds reflects seekable range duration")
+    func maxLookbackFromSeekableRange() {
+        let (player, mock, _) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 1800)
+
+        #expect(player.maxLookbackSeconds == 1800)
+    }
+
+    @Test("maxLookbackSeconds is capped at 3600")
+    func maxLookbackCappedAtOneHour() {
+        let (player, mock, _) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 7200)
+
+        #expect(player.maxLookbackSeconds == 3600)
+    }
+
+    @Test("maxLookbackSeconds is zero with no seekable range")
+    func maxLookbackZeroWithNoRange() {
+        let (player, _, _) = makePlayer()
+
+        #expect(player.maxLookbackSeconds == 0)
+    }
+
+    // MARK: - Seeking
+
+    @Test("seek calls underlying player with computed target time")
+    func seekCallsUnderlyingPlayer() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 100, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seek(secondsBehindLive: 60)
+
+        #expect(mock.seekCallCount == 1)
+        let expectedTarget = 100.0 + 3600.0 - 60.0
+        #expect(abs(mock.lastSeekTime!.seconds - expectedTarget) < 0.01)
+    }
+
+    @Test("seek clamps offset to maxLookbackSeconds")
+    func seekClampsToMaxLookback() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 1800)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        // Request 3600 but range is only 1800
+        await player.seek(secondsBehindLive: 3600)
+
+        let expectedTarget = 0.0 + 1800.0 - 1800.0
+        #expect(abs(mock.lastSeekTime!.seconds - expectedTarget) < 0.01)
+    }
+
+    @Test("seek clamps negative offset to zero")
+    func seekClampsNegativeOffset() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seek(secondsBehindLive: -10)
+
+        // Should seek to live edge (offset 0)
+        let expectedTarget = 3600.0
+        #expect(abs(mock.lastSeekTime!.seconds - expectedTarget) < 0.01)
+    }
+
+    @Test("seekToLive seeks to live edge")
+    func seekToLiveSeeksToEdge() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 100, duration: 3600)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seekToLive()
+
+        #expect(mock.seekCallCount == 1)
+        let expectedTarget = 100.0 + 3600.0
+        #expect(abs(mock.lastSeekTime!.seconds - expectedTarget) < 0.01)
+    }
+
+    @Test("seek does nothing with no seekable range")
+    func seekNoOpWithoutRange() async throws {
+        let (player, mock, nc) = makePlayer()
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await player.seek(secondsBehindLive: 60)
+
+        #expect(mock.seekCallCount == 0)
+    }
+
+    // MARK: - Time Position Stream
+
+    @Test("Time position stream emits updates while playing")
+    func timePositionStreamEmits() async throws {
+        let (player, mock, nc) = makePlayer()
+        mock.setSeekableRange(start: 0, duration: 3600)
+        mock.setCurrentTimeBehindLive(30)
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+
+        var positions: [TimeInterval] = []
+        let task = Task {
+            for await position in player.timePositionStream {
+                positions.append(position)
+                if positions.count >= 2 { break }
+            }
+        }
+
+        await withTaskCancellation(of: task, after: .seconds(3))
+
+        #expect(positions.count >= 1)
+    }
+
+    // MARK: - Render Tap
+
+    @Test("installRenderTap and removeRenderTap are no-ops")
+    func renderTapNoOps() {
+        let (player, _, _) = makePlayer()
+
+        player.installRenderTap()
+        player.removeRenderTap()
+
+        // No crash, no effect
+        #expect(player.state == .idle)
+    }
+
+    // MARK: - Event Stream
+
+    @Test("Stall yields stall event")
+    func stallYieldsEvent() async throws {
+        let (player, _, nc) = makePlayer()
+        var events: [AudioPlayerInternalEvent] = []
+
+        let task = Task {
+            for await event in player.eventStream {
+                events.append(event)
+                if events.count >= 1 { break }
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        simulateStall(on: nc)
+
+        await withTaskCancellation(of: task, after: .seconds(2))
+
+        #expect(events.contains(where: {
+            if case .stall = $0 { return true }
+            return false
+        }))
+    }
+
+    @Test("Recovery after stall yields recovery event")
+    func recoveryYieldsEvent() async throws {
+        let (player, _, nc) = makePlayer()
+        var events: [AudioPlayerInternalEvent] = []
+
+        let task = Task {
+            for await event in player.eventStream {
+                events.append(event)
+                if events.count >= 2 { break }
+            }
+        }
+
+        try await Task.sleep(for: .milliseconds(50))
+
+        player.play()
+        simulateRateChange(rate: 1.0, on: nc)
+        simulateStall(on: nc)
+        simulateRateChange(rate: 1.0, on: nc)
+
+        await withTaskCancellation(of: task, after: .seconds(2))
+
+        #expect(events.contains(where: {
+            if case .recovery = $0 { return true }
+            return false
+        }))
+    }
+
+    // MARK: - Analytics
+
+    @Test("Play captures analytics event")
+    func playAnalytics() {
+        let (player, _, _) = makePlayer()
+
+        player.play()
+
+        #expect(player.state == .loading)
+    }
+
+    // MARK: - Helpers
+
+    private func makePlayer() -> (HLSPlayer, MockHLSAVPlayer, NotificationCenter) {
+        let mock = MockHLSAVPlayer()
+        let nc = NotificationCenter()
+        let player = HLSPlayer(
+            player: mock,
+            analytics: nil,
+            notificationCenter: nc
+        )
+        return (player, mock, nc)
+    }
+
+    private func simulateRateChange(rate: Float, on nc: NotificationCenter) {
+        nc.post(
+            name: AVPlayer.rateDidChangeNotification,
+            object: nil,
+            userInfo: ["rate": rate]
+        )
+    }
+
+    private func simulateStall(on nc: NotificationCenter) {
+        nc.post(name: .AVPlayerItemPlaybackStalled, object: nil)
+    }
+
+    private func simulateFailure(on nc: NotificationCenter) {
+        nc.post(
+            name: .AVPlayerItemFailedToPlayToEndTime,
+            object: nil,
+            userInfo: [AVPlayerItemFailedToPlayToEndTimeErrorKey: NSError(domain: "test", code: -1)]
+        )
+    }
+
+    /// Cancels task after timeout if it hasn't completed.
+    private func withTaskCancellation(of task: Task<Void, Never>, after timeout: Duration) async {
+        let timeoutTask = Task {
+            try? await Task.sleep(for: timeout)
+            task.cancel()
+        }
+        await task.value
+        timeoutTask.cancel()
+    }
+}

--- a/Shared/Playback/Tests/HLSPlayerTests/MockHLSAVPlayer.swift
+++ b/Shared/Playback/Tests/HLSPlayerTests/MockHLSAVPlayer.swift
@@ -1,0 +1,94 @@
+//
+//  MockHLSAVPlayer.swift
+//  HLSPlayerTests
+//
+//  Mock implementation of HLSAVPlayerProtocol for testing HLSPlayer.
+//  Provides controllable seekable time ranges, current time, and seek behavior.
+//
+//  Created by Jake Bromberg on 03/31/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import AVFoundation
+import CoreMedia
+@testable import HLSPlayerModule
+
+@MainActor
+final class MockHLSAVPlayer: HLSAVPlayerProtocol {
+    var rate: Float = 0
+    var playCallCount = 0
+    var pauseCallCount = 0
+    var seekCallCount = 0
+    var lastSeekTime: CMTime?
+    var seekResult = true
+    var autoSetRateOnPlay = true
+
+    var mockCurrentTime: CMTime = .zero
+    var mockSeekableTimeRanges: [NSValue] = []
+
+    func play() {
+        playCallCount += 1
+        if autoSetRateOnPlay {
+            rate = 1.0
+        }
+    }
+
+    func pause() {
+        pauseCallCount += 1
+        rate = 0
+    }
+
+    func currentTime() -> CMTime {
+        mockCurrentTime
+    }
+
+    var seekableTimeRanges: [NSValue] {
+        mockSeekableTimeRanges
+    }
+
+    func seek(to time: CMTime) async -> Bool {
+        seekCallCount += 1
+        lastSeekTime = time
+        if seekResult {
+            mockCurrentTime = time
+        }
+        return seekResult
+    }
+
+    func reset() {
+        rate = 0
+        playCallCount = 0
+        pauseCallCount = 0
+        seekCallCount = 0
+        lastSeekTime = nil
+        seekResult = true
+        mockCurrentTime = .zero
+        mockSeekableTimeRanges = []
+    }
+
+    // MARK: - Helpers
+
+    /// Sets up a seekable range simulating a live HLS stream.
+    ///
+    /// - Parameters:
+    ///   - start: The start time in seconds.
+    ///   - duration: The duration of the seekable range in seconds.
+    func setSeekableRange(start: TimeInterval, duration: TimeInterval) {
+        let range = CMTimeRange(
+            start: CMTime(seconds: start, preferredTimescale: 600),
+            duration: CMTime(seconds: duration, preferredTimescale: 600)
+        )
+        mockSeekableTimeRanges = [NSValue(timeRange: range)]
+    }
+
+    /// Sets the current time to be a given number of seconds behind the live edge.
+    func setCurrentTimeBehindLive(_ secondsBehind: TimeInterval) {
+        guard let range = mockSeekableTimeRanges.first?.timeRangeValue else { return }
+        let liveEdge = range.start + range.duration
+        mockCurrentTime = CMTime(
+            seconds: liveEdge.seconds - secondsBehind,
+            preferredTimescale: 600
+        )
+    }
+}

--- a/WXYC/iOS/Tests/WXYC.xctestplan
+++ b/WXYC/iOS/Tests/WXYC.xctestplan
@@ -111,6 +111,13 @@
     },
     {
       "target" : {
+        "containerPath" : "container:Shared\/Playback",
+        "identifier" : "HLSPlayerTests",
+        "name" : "HLSPlayerTests"
+      }
+    },
+    {
+      "target" : {
         "containerPath" : "container:Shared\/Wallpaper",
         "identifier" : "WallpaperTests",
         "name" : "WallpaperTests"


### PR DESCRIPTION
## Summary

- Add `TimeShiftablePlayer` protocol to PlaybackCore extending `AudioPlayerProtocol` with seeking, live edge detection, and time position streaming
- Implement `HLSPlayer` module with AVPlayer-based HLS playback and seeking via `seekableTimeRanges`
- Add `HLSAVPlayerProtocol` abstraction for testable AVPlayer interactions (same pattern as `PlayerProtocol` in RadioPlayer)
- Add `RadioStation.hlsStreamURL` property pointing to `hls.wxyc.org/live/live.m3u8`
- Add `.hlsPlayer` case to `PlayerControllerType` enum
- Add `HLSPlayerTests` (27 tests) to `WXYC.xctestplan`

Closes #165

## Test plan

- [x] `HLSPlayerTests` pass: state transitions, seeking, isAtLiveEdge, secondsBehindLive, maxLookbackSeconds, timePositionStream, event stream, audio buffer stream
- [x] All existing `swift test` pass (237 tests across 35 suites)
- [x] `swift build` succeeds
- [x] `xcodebuild build` succeeds (full app target)
- [x] `AudioPlayerProtocol` unchanged
- [x] `RadioPlayer` and `MP3Streamer` unchanged