### PR TITLE
Wire authentication into PlaycutMetadataService

### DIFF
--- a/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
@@ -10,6 +10,7 @@ import Analytics
 import AppIntents
 import AppServices
 import Metadata
+import MusicShareKit
 import Playlist
 import SwiftUI
 import UIKit
@@ -30,7 +31,7 @@ struct PlaycutDetailView: View {
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.reviewRequestService) var reviewRequestService
 
-    private let metadataService = PlaycutMetadataService()
+    private let metadataService = PlaycutMetadataService(tokenProvider: MusicShareKit.authService)
     
     private var artworkGeometryID: String {
         "playcut-artwork-\(playcut.id)"


### PR DESCRIPTION
## Summary

Pass `MusicShareKit.authService` as the token provider when creating `PlaycutMetadataService` in `PlaycutDetailView`. Without this, every proxy metadata request goes out without auth and gets `401` back, resulting in no metadata for any release.

One-line fix: `PlaycutMetadataService()` -> `PlaycutMetadataService(tokenProvider: MusicShareKit.authService)`

Closes #169

## Test plan

- [ ] Build succeeds
- [ ] Metadata tests pass (`swift test` in `Shared/Metadata` — 101 tests)
- [ ] Open a playcut detail view in the app — should show release year, genres, label, streaming links
- [ ] Verify `Authorization: Bearer <token>` header appears in proxy requests (HTTP status validation test already covers this: `PlaycutMetadataServiceHTTPTests.includesAuthorizationHeader`)