### PR TITLE
Extract detail section header font into shared WXUI constant

### DIFF
--- a/Shared/WXUI/Sources/WXUI/Font+Typography.swift
+++ b/Shared/WXUI/Sources/WXUI/Font+Typography.swift
@@ -1,0 +1,16 @@
+//
+//  Font+Typography.swift
+//  WXUI
+//
+//  Shared typography constants for the WXYC design system. Centralizes repeated font chains so detail views and section headers use a single source of truth.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import SwiftUI
+
+extension Font {
+    /// Small-caps headline used for detail section headers ("About the Artist", "Add it to your library", "More Info", etc.).
+    public static let detailSectionHeader: Font = .headline.smallCaps()
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistBioSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistBioSection.swift
@@ -10,6 +10,7 @@
 
 import SwiftUI
 import Metadata
+import WXUI
 
 struct ArtistBioSection: View {
     let bio: String
@@ -22,7 +23,7 @@ struct ArtistBioSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 8) {
             Text("About the Artist")
-                .font(.headline.smallCaps())
+                .font(.detailSectionHeader)
                 .foregroundStyle(.primary)
             
             parsedBioText

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ExternalLinksSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ExternalLinksSection.swift
@@ -10,6 +10,7 @@
 
 import SwiftUI
 import Metadata
+import WXUI
 
 struct ExternalLinksSection: View {
     let metadata: PlaycutMetadata
@@ -18,7 +19,7 @@ struct ExternalLinksSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("More Info")
-                .font(.headline)
+                .font(.detailSectionHeader)
                 .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/StreamingLinksSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/StreamingLinksSection.swift
@@ -10,6 +10,7 @@
 
 import SwiftUI
 import Metadata
+import WXUI
 
 struct StreamingLinksSection: View {
     let metadata: PlaycutMetadata
@@ -19,7 +20,7 @@ struct StreamingLinksSection: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
             Text("Add it to your library")
-                .font(.headline.smallCaps())
+                .font(.detailSectionHeader)
                 .foregroundStyle(.primary)
                 .frame(maxWidth: .infinity, alignment: .leading)
             


### PR DESCRIPTION
## Summary

- Add `Font.detailSectionHeader` (`.headline.smallCaps()`) to the WXUI package as a shared typography constant
- Replace inline font chains in ArtistBioSection, StreamingLinksSection, and ExternalLinksSection with the new constant
- Normalize ExternalLinksSection's header font from plain `.headline` to `.headline.smallCaps()` to match the other detail sections

Closes #180

## Test plan

- [x] Build succeeds with `xcodebuild build -scheme WXYC -destination 'platform=iOS Simulator,id=7DB27227-F733-46FF-8520-5866676EDAD7' -skipMacroValidation`
- [ ] Verify playcut detail view section headers render with small-caps headline font
- [ ] Verify "More Info" section header now matches "About the Artist" and "Add it to your library" styling
