### PR TITLE
Standardize cache key generation across packages

### DIFF
--- a/Shared/ColorPalette/Sources/ColorPalette/ColorPaletteCacheKey.swift
+++ b/Shared/ColorPalette/Sources/ColorPalette/ColorPaletteCacheKey.swift
@@ -1,0 +1,28 @@
+//
+//  ColorPaletteCacheKey.swift
+//  ColorPalette
+//
+//  Cache key generation for color palette data. Follows the MetadataCacheKey pattern
+//  to provide consistent, namespaced cache keys.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+/// Utility for generating consistent cache keys for color palettes.
+///
+/// Palette cache keys incorporate both the generation mode and the source identifier
+/// (typically an artist-album pair) to avoid collisions between different palettes
+/// generated from the same artwork.
+public enum ColorPaletteCacheKey {
+
+    /// Cache key for a color palette extracted from artwork.
+    ///
+    /// - Parameters:
+    ///   - mode: The palette generation mode (triad, complementary, etc.)
+    ///   - identifier: A unique identifier for the source image (typically artist-album)
+    /// - Returns: Cache key in format `palette-{mode}-{identifier}`
+    public static func palette(mode: PaletteMode, identifier: String) -> String {
+        "palette-\(mode.rawValue)-\(identifier)"
+    }
+}

--- a/Shared/ColorPalette/Sources/ColorPalette/ColorPaletteService.swift
+++ b/Shared/ColorPalette/Sources/ColorPalette/ColorPaletteService.swift
@@ -43,7 +43,7 @@ public actor ColorPaletteService {
         cacheKey: String,
         mode: PaletteMode
     ) async throws -> ColorPalette {
-        let fullCacheKey = "palette_\(mode.rawValue)_\(cacheKey)"
+        let fullCacheKey = ColorPaletteCacheKey.palette(mode: mode, identifier: cacheKey)
 
         // Check for existing in-flight task
         if let existingTask = inflightTasks[fullCacheKey],
@@ -94,7 +94,7 @@ public actor ColorPaletteService {
             results[mode] = palette
 
             // Cache each palette
-            let fullCacheKey = "palette_\(mode.rawValue)_\(cacheKey)"
+            let fullCacheKey = ColorPaletteCacheKey.palette(mode: mode, identifier: cacheKey)
             await cacheCoordinator.set(value: palette, for: fullCacheKey, lifespan: .thirtyDays)
         }
 

--- a/Shared/ColorPalette/Tests/ColorPaletteTests/ColorPaletteCacheKeyTests.swift
+++ b/Shared/ColorPalette/Tests/ColorPaletteTests/ColorPaletteCacheKeyTests.swift
@@ -1,0 +1,44 @@
+//
+//  ColorPaletteCacheKeyTests.swift
+//  ColorPalette
+//
+//  Tests for ColorPaletteCacheKey cache key generation.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+@testable import ColorPalette
+
+@Suite("ColorPaletteCacheKey Tests")
+struct ColorPaletteCacheKeyTests {
+
+    @Test("palette key includes mode and identifier")
+    func paletteKeyIncludesModeAndIdentifier() {
+        let key = ColorPaletteCacheKey.palette(mode: .triad, identifier: "Stereolab-Aluminum Tunes")
+        #expect(key.contains("triad"))
+        #expect(key.contains("Stereolab-Aluminum Tunes"))
+    }
+
+    @Test("palette key differs for different modes")
+    func paletteKeyDiffersForDifferentModes() {
+        let triadKey = ColorPaletteCacheKey.palette(mode: .triad, identifier: "Cat Power-Moon Pix")
+        let complementaryKey = ColorPaletteCacheKey.palette(mode: .complementary, identifier: "Cat Power-Moon Pix")
+        #expect(triadKey != complementaryKey)
+    }
+
+    @Test("palette key differs for different identifiers")
+    func paletteKeyDiffersForDifferentIdentifiers() {
+        let key1 = ColorPaletteCacheKey.palette(mode: .triad, identifier: "Juana Molina-DOGA")
+        let key2 = ColorPaletteCacheKey.palette(mode: .triad, identifier: "Jessica Pratt-On Your Own Love Again")
+        #expect(key1 != key2)
+    }
+
+    @Test("palette key is consistent for same inputs")
+    func paletteKeyIsConsistentForSameInputs() {
+        let key1 = ColorPaletteCacheKey.palette(mode: .square, identifier: "Sessa-Pequena Vertigem de Amor")
+        let key2 = ColorPaletteCacheKey.palette(mode: .square, identifier: "Sessa-Pequena Vertigem de Amor")
+        #expect(key1 == key2)
+    }
+}

--- a/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
+++ b/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
@@ -59,7 +59,7 @@ public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
     }
 
     private func resolve(type: String, id: Int) async throws -> String {
-        let cacheKey = "discogs-\(type)-\(id)"
+        let cacheKey = MetadataCacheKey.discogsEntity(type: type, id: id)
 
         // Check cache first
         if let cached: String = try? await cache.value(for: cacheKey) {

--- a/Shared/Metadata/Sources/Metadata/MetadataCacheKey.swift
+++ b/Shared/Metadata/Sources/Metadata/MetadataCacheKey.swift
@@ -49,4 +49,15 @@ public enum MetadataCacheKey {
     public static func streaming(artistName: String, songTitle: String) -> String {
         "streaming-\(artistName)-\(songTitle)"
     }
+
+    /// Cache key for resolved Discogs entity names (artists, releases, masters).
+    ///
+    /// Entity names essentially never change and can be cached for 30 days.
+    /// - Parameters:
+    ///   - type: The Discogs entity type (e.g., "artist", "release", "master")
+    ///   - id: The Discogs entity ID
+    /// - Returns: Cache key in format `discogs-{type}-{id}`
+    public static func discogsEntity(type: String, id: Int) -> String {
+        "discogs-\(type)-\(id)"
+    }
 }

--- a/Shared/Metadata/Tests/MetadataTests/DiscogsAPIEntityResolverCachingTests.swift
+++ b/Shared/Metadata/Tests/MetadataTests/DiscogsAPIEntityResolverCachingTests.swift
@@ -293,8 +293,8 @@ struct DiscogsAPIEntityResolverCachingTests {
         _ = try await resolver.resolveMaster(id: 3)
 
         // Then
-        #expect(mockCache.keysSet.contains("discogs-artist-1"))
-        #expect(mockCache.keysSet.contains("discogs-release-2"))
-        #expect(mockCache.keysSet.contains("discogs-master-3"))
+        #expect(mockCache.keysSet.contains(MetadataCacheKey.discogsEntity(type: "artist", id: 1)))
+        #expect(mockCache.keysSet.contains(MetadataCacheKey.discogsEntity(type: "release", id: 2)))
+        #expect(mockCache.keysSet.contains(MetadataCacheKey.discogsEntity(type: "master", id: 3)))
     }
 }

--- a/Shared/Metadata/Tests/MetadataTests/MetadataCacheKeyTests.swift
+++ b/Shared/Metadata/Tests/MetadataTests/MetadataCacheKeyTests.swift
@@ -1,0 +1,72 @@
+//
+//  MetadataCacheKeyTests.swift
+//  Metadata
+//
+//  Tests for MetadataCacheKey cache key generation including Discogs entity keys.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+@testable import Metadata
+
+@Suite("MetadataCacheKey Tests")
+struct MetadataCacheKeyTests {
+
+    // MARK: - Existing Key Tests
+
+    @Test("artist key uses discogs ID")
+    func artistKeyUsesDiscogsId() {
+        let key = MetadataCacheKey.artist(discogsId: 12345)
+        #expect(key == "artist-12345")
+    }
+
+    @Test("album key uses artist name and release title")
+    func albumKeyUsesArtistAndRelease() {
+        let key = MetadataCacheKey.album(artistName: "Stereolab", releaseTitle: "Aluminum Tunes")
+        #expect(key == "album-Stereolab-Aluminum Tunes")
+    }
+
+    @Test("album key uses unknown for empty release title")
+    func albumKeyUsesUnknownForEmptyRelease() {
+        let key = MetadataCacheKey.album(artistName: "Chuquimamani-Condori", releaseTitle: "")
+        #expect(key == "album-Chuquimamani-Condori-unknown")
+    }
+
+    @Test("streaming key uses artist name and song title")
+    func streamingKeyUsesArtistAndSong() {
+        let key = MetadataCacheKey.streaming(artistName: "Duke Ellington & John Coltrane", songTitle: "In a Sentimental Mood")
+        #expect(key == "streaming-Duke Ellington & John Coltrane-In a Sentimental Mood")
+    }
+
+    // MARK: - Discogs Entity Key Tests
+
+    @Test("discogs entity key includes type and ID")
+    func discogsEntityKeyIncludesTypeAndId() {
+        let key = MetadataCacheKey.discogsEntity(type: "artist", id: 42)
+        #expect(key.contains("artist"))
+        #expect(key.contains("42"))
+    }
+
+    @Test("discogs entity key differs for different types")
+    func discogsEntityKeyDiffersForDifferentTypes() {
+        let artistKey = MetadataCacheKey.discogsEntity(type: "artist", id: 100)
+        let releaseKey = MetadataCacheKey.discogsEntity(type: "release", id: 100)
+        #expect(artistKey != releaseKey)
+    }
+
+    @Test("discogs entity key differs for different IDs")
+    func discogsEntityKeyDiffersForDifferentIds() {
+        let key1 = MetadataCacheKey.discogsEntity(type: "artist", id: 1)
+        let key2 = MetadataCacheKey.discogsEntity(type: "artist", id: 2)
+        #expect(key1 != key2)
+    }
+
+    @Test("discogs entity key is consistent for same inputs")
+    func discogsEntityKeyIsConsistent() {
+        let key1 = MetadataCacheKey.discogsEntity(type: "master", id: 999)
+        let key2 = MetadataCacheKey.discogsEntity(type: "master", id: 999)
+        #expect(key1 == key2)
+    }
+}

--- a/Shared/Playlist/Sources/Playlist/PlaylistCacheKey.swift
+++ b/Shared/Playlist/Sources/Playlist/PlaylistCacheKey.swift
@@ -1,0 +1,22 @@
+//
+//  PlaylistCacheKey.swift
+//  Playlist
+//
+//  Cache key generation for playlist data. Follows the MetadataCacheKey pattern
+//  to provide consistent, namespaced cache keys.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+/// Utility for generating consistent cache keys for playlist data.
+///
+/// The playlist cache stores the full playlist response with a 15-minute TTL.
+public enum PlaylistCacheKey {
+
+    /// Cache key for the current playlist.
+    ///
+    /// Only one playlist is cached at a time. The key is static because
+    /// the playlist represents the station's current state.
+    public static let playlist = "com.wxyc.playlist.cache"
+}

--- a/Shared/Playlist/Sources/Playlist/PlaylistService.swift
+++ b/Shared/Playlist/Sources/Playlist/PlaylistService.swift
@@ -19,7 +19,7 @@ public final actor PlaylistService: Sendable {
     private var currentPlaylist: Playlist = .empty
     private var fetchTask: Task<Void, Never>?
     private let cacheCoordinator: CacheCoordinator
-    private static let cacheKey = "com.wxyc.playlist.cache"
+    private static let cacheKey = PlaylistCacheKey.playlist
     private static let cacheLifespan: TimeInterval = 15 * 60 // 15 minutes
     
     /// Collection of continuations for broadcasting to multiple observers

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistCacheKeyTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistCacheKeyTests.swift
@@ -1,0 +1,29 @@
+//
+//  PlaylistCacheKeyTests.swift
+//  Playlist
+//
+//  Tests for PlaylistCacheKey cache key generation.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+@testable import Playlist
+
+@Suite("PlaylistCacheKey Tests")
+struct PlaylistCacheKeyTests {
+
+    @Test("playlist key returns consistent value")
+    func playlistKeyReturnsConsistentValue() {
+        let key1 = PlaylistCacheKey.playlist
+        let key2 = PlaylistCacheKey.playlist
+        #expect(key1 == key2)
+    }
+
+    @Test("playlist key uses namespaced format")
+    func playlistKeyUsesNamespacedFormat() {
+        let key = PlaylistCacheKey.playlist
+        #expect(key.contains("playlist"))
+    }
+}

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceBackgroundRefreshTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceBackgroundRefreshTests.swift
@@ -31,7 +31,7 @@ struct PlaylistServiceBackgroundRefreshTests {
 
         await cacheCoordinator.set(
             value: oldPlaylist,
-            for: "com.wxyc.playlist.cache",
+            for: PlaylistCacheKey.playlist,
             lifespan: 15 * 60
         )
 
@@ -51,7 +51,7 @@ struct PlaylistServiceBackgroundRefreshTests {
         let fetched = await service.fetchAndCachePlaylist()
         
         // Then - Cache should be updated with new data
-        let cached: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+        let cached: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
         #expect(cached.playcuts.first?.songTitle == "New Song")
         #expect(cached.playcuts.first?.songTitle != "Old Song")
         #expect(fetched.playcuts.first?.songTitle == "New Song")
@@ -68,7 +68,7 @@ struct PlaylistServiceBackgroundRefreshTests {
 
         await cacheCoordinator.set(
             value: cachedPlaylist,
-            for: "com.wxyc.playlist.cache",
+            for: PlaylistCacheKey.playlist,
             lifespan: 15 * 60
         )
 

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceCachingTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceCachingTests.swift
@@ -93,7 +93,7 @@ struct PlaylistServiceCachingTests {
         // Cache the playlist
         await cacheCoordinator.set(
             value: cachedPlaylist,
-            for: "com.wxyc.playlist.cache",
+            for: PlaylistCacheKey.playlist,
             lifespan: 15 * 60
         )
 
@@ -130,7 +130,7 @@ struct PlaylistServiceCachingTests {
             timestamp: Date.timeIntervalSinceReferenceDate - (16 * 60), // 16 minutes ago
             lifespan: 15 * 60 // 15 minute lifespan
         )
-        mockCache.set(encoded, metadata: expiredMetadata, for: "com.wxyc.playlist.cache")
+        mockCache.set(encoded, metadata: expiredMetadata, for: PlaylistCacheKey.playlist)
 
         // When - Create service
         let mockFetcher = MockPlaylistFetcher()
@@ -166,7 +166,7 @@ struct PlaylistServiceCachingTests {
 
         await cacheCoordinator.set(
             value: cachedPlaylist,
-            for: "com.wxyc.playlist.cache",
+            for: PlaylistCacheKey.playlist,
             lifespan: 15 * 60
         )
 
@@ -189,7 +189,7 @@ struct PlaylistServiceCachingTests {
         #expect(mockFetcher.callCount == 1)
     
         // And - Cache should be updated with fresh data
-        let cached: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+        let cached: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
         #expect(cached.playcuts.first?.songTitle == "Fresh Song")
     }
 
@@ -211,7 +211,7 @@ struct PlaylistServiceCachingTests {
         _ = await service.fetchAndCachePlaylist()
 
         // Then - Cache should be updated (timestamp refreshed)
-        let cached: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+        let cached: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
         #expect(cached.playcuts.first?.songTitle == "Same Song")
     }
 
@@ -239,7 +239,7 @@ struct PlaylistServiceCachingTests {
         try await Task.sleep(for: .milliseconds(150))
 
         // Then - Cache should contain the fetched playlist
-        let cached: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+        let cached: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
         #expect(cached.playcuts.first?.songTitle == "Fetched Song")
     }
         
@@ -259,12 +259,12 @@ struct PlaylistServiceCachingTests {
             timestamp: Date.timeIntervalSinceReferenceDate - (16 * 60), // 16 minutes ago
             lifespan: 15 * 60 // 15 minute lifespan
         )
-        mockCache.set(encoded, metadata: expiredMetadata, for: "com.wxyc.playlist.cache")
+        mockCache.set(encoded, metadata: expiredMetadata, for: PlaylistCacheKey.playlist)
     
         // When - Try to retrieve
         // Then - Should throw noCachedResult error
         await #expect(throws: CacheCoordinator.Error.noCachedResult) {
-            let _: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+            let _: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
         }
     }
 
@@ -282,10 +282,10 @@ struct PlaylistServiceCachingTests {
             timestamp: Date.timeIntervalSinceReferenceDate - (10 * 60), // 10 minutes ago
             lifespan: 15 * 60
         )
-        mockCache.set(encoded, metadata: recentMetadata, for: "com.wxyc.playlist.cache")
+        mockCache.set(encoded, metadata: recentMetadata, for: PlaylistCacheKey.playlist)
         
         // When - Try to retrieve
-        let cached: Playlist = try await cacheCoordinator.value(for: "com.wxyc.playlist.cache")
+        let cached: Playlist = try await cacheCoordinator.value(for: PlaylistCacheKey.playlist)
 
         // Then - Should succeed
         #expect(cached.playcuts.first?.songTitle == "Recent Song")

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceTests.swift
@@ -391,7 +391,7 @@ struct PlaylistServiceTests {
         // Pre-populate the cache
         await cacheCoordinator.set(
             value: cachedPlaylist,
-            for: "com.wxyc.playlist.cache",
+            for: PlaylistCacheKey.playlist,
             lifespan: 15 * 60
         )
 


### PR DESCRIPTION
## Summary

- Add `PlaylistCacheKey` enum in Playlist package for playlist cache key generation
- Add `ColorPaletteCacheKey` enum in ColorPalette package for palette cache key generation
- Add `MetadataCacheKey.discogsEntity(type:id:)` for Discogs entity resolution cache keys
- Update all production code to use new cache key types instead of inline strings
- Update existing tests and add dedicated cache key test suites (14 new tests)

Closes #182

## Test plan

- [x] PlaylistCacheKeyTests: verify key consistency and namespaced format
- [x] ColorPaletteCacheKeyTests: verify mode/identifier incorporation and uniqueness
- [x] MetadataCacheKeyTests: verify all key formats including new discogsEntity
- [x] Existing PlaylistServiceCachingTests pass with new key references
- [x] Existing PlaylistServiceBackgroundRefreshTests pass with new key references
- [x] Existing ColorPaletteServiceTests pass with updated key format
- [x] Existing DiscogsAPIEntityResolverCachingTests pass with MetadataCacheKey references
- [x] Full build succeeds
