### PR TITLE
Extract timedOperation utility for network service layers

### DIFF
--- a/Shared/Core/Package.swift
+++ b/Shared/Core/Package.swift
@@ -26,7 +26,10 @@ let package = Package(
         ),
         .testTarget(
             name: "CoreTests",
-            dependencies: ["Core"]
+            dependencies: [
+                "Core",
+                .product(name: "LoggerTesting", package: "Logger"),
+            ]
         ),
     ]
 )

--- a/Shared/Core/Sources/Core/TimedOperation.swift
+++ b/Shared/Core/Sources/Core/TimedOperation.swift
@@ -1,0 +1,59 @@
+//
+//  TimedOperation.swift
+//  Core
+//
+//  Generic utility for wrapping async operations with timing, logging,
+//  CancellationError handling, and error reporting. Reduces boilerplate
+//  in network service layers that share this pattern.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Logger
+import struct Logger.Category
+
+/// Executes an async throwing operation with standardized timing, logging, and error handling.
+///
+/// On success, logs the duration and returns the result. On `CancellationError`, returns
+/// the fallback silently (task cancellation is normal during cleanup). On any other error,
+/// reports it via the error reporter with the elapsed duration and returns the fallback.
+///
+/// - Parameters:
+///   - context: A short label describing the operation (e.g., `"fetchPlaylist"`).
+///     Used in log messages and error reports.
+///   - category: The log category for filtering (e.g., `.network`, `.caching`).
+///   - fallback: The value to return when the operation fails or is cancelled.
+///   - errorReporter: Where to send non-cancellation errors. Defaults to the
+///     global ``ErrorReporting/shared`` reporter.
+///   - operation: The async throwing closure to execute.
+/// - Returns: The operation's result on success, or `fallback` on failure.
+public func timedOperation<T: Sendable>(
+    context: String,
+    category: Category,
+    fallback: T,
+    errorReporter: any ErrorReporter = ErrorReporting.shared,
+    operation: sending () async throws -> T
+) async -> T {
+    Log(.info, category: category, "\(context): starting")
+    let timer = Timer.start()
+
+    do {
+        let result = try await operation()
+        let duration = timer.duration()
+        Log(.info, category: category, "\(context): succeeded in \(duration)s")
+        return result
+    } catch is CancellationError {
+        return fallback
+    } catch {
+        let duration = timer.duration()
+        errorReporter.report(
+            error,
+            context: context,
+            category: category,
+            additionalData: ["duration": "\(duration)"]
+        )
+        return fallback
+    }
+}

--- a/Shared/Core/Tests/CoreTests/TimedOperationTests.swift
+++ b/Shared/Core/Tests/CoreTests/TimedOperationTests.swift
@@ -1,0 +1,145 @@
+//
+//  TimedOperationTests.swift
+//  Core
+//
+//  Tests for the timedOperation utility function that wraps async operations
+//  with timing, logging, error handling, and fallback behavior.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Logger
+import LoggerTesting
+@testable import Core
+
+// MARK: - TimedOperation Tests
+
+@Suite("TimedOperation Tests")
+struct TimedOperationTests {
+    @Test("returns the result of a successful operation")
+    func returnsResultOnSuccess() async {
+        let result = await timedOperation(
+            context: "test",
+            category: .network,
+            fallback: "fallback"
+        ) {
+            "success"
+        }
+
+        #expect(result == "success")
+    }
+
+    @Test("returns fallback when the operation throws")
+    func returnsFallbackOnError() async {
+        let result = await timedOperation(
+            context: "test",
+            category: .network,
+            fallback: "fallback"
+        ) {
+            throw URLError(.notConnectedToInternet)
+            return "unreachable"
+        }
+
+        #expect(result == "fallback")
+    }
+
+    @Test("returns fallback on CancellationError without reporting")
+    func returnsFallbackOnCancellationError() async {
+        let reporter = MockErrorReporter()
+
+        let result = await timedOperation(
+            context: "test",
+            category: .network,
+            fallback: 0,
+            errorReporter: reporter
+        ) {
+            throw CancellationError()
+            return 42
+        }
+
+        #expect(result == 0)
+        #expect(reporter.allReportedErrors.isEmpty)
+    }
+
+    @Test("reports non-cancellation errors to the error reporter")
+    func reportsErrorsToReporter() async {
+        let reporter = MockErrorReporter()
+
+        let _ = await timedOperation(
+            context: "fetchWidgets",
+            category: .network,
+            fallback: [String](),
+            errorReporter: reporter
+        ) {
+            throw URLError(.badServerResponse)
+            return ["widget"]
+        }
+
+        #expect(reporter.allReportedErrors.count == 1)
+        let reported = reporter.allReportedErrors.first
+        #expect(reported?.context == "fetchWidgets")
+        #expect(reported?.category == .network)
+        #expect(reported?.additionalData["duration"] != nil)
+    }
+
+    @Test("includes duration in additional data for reported errors")
+    func includesDurationInErrorReport() async {
+        let reporter = MockErrorReporter()
+
+        let _ = await timedOperation(
+            context: "slowFetch",
+            category: .caching,
+            fallback: "",
+            errorReporter: reporter
+        ) {
+            throw NSError(domain: "test", code: 1)
+            return "never"
+        }
+
+        let duration = reporter.allReportedErrors.first?.additionalData["duration"]
+        #expect(duration != nil)
+    }
+
+    @Test("passes through the return type correctly for non-optional types")
+    func worksWithNonOptionalTypes() async {
+        let result: Int = await timedOperation(
+            context: "intOp",
+            category: .general,
+            fallback: -1
+        ) {
+            42
+        }
+
+        #expect(result == 42)
+    }
+
+    @Test("passes through the return type correctly for optional types")
+    func worksWithOptionalTypes() async {
+        let result: String? = await timedOperation(
+            context: "optOp",
+            category: .general,
+            fallback: nil
+        ) {
+            "hello"
+        }
+
+        #expect(result == "hello")
+    }
+
+    @Test("returns nil fallback for optional types on error")
+    func returnsNilFallbackOnError() async {
+        let result: String? = await timedOperation(
+            context: "optOp",
+            category: .general,
+            fallback: nil
+        ) {
+            throw URLError(.timedOut)
+            return "unreachable"
+        }
+
+        #expect(result == nil)
+    }
+}

--- a/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
+++ b/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
@@ -30,10 +30,12 @@ public actor PlaycutMetadataService {
     private let urlSession: URLSession
     private let decoder: JSONDecoder
     private let cache: CacheCoordinator
+    private let errorReporter: any ErrorReporter
 
     public init(
         baseURL: URL = URL(string: "https://api.wxyc.org")!,
-        tokenProvider: SessionTokenProvider? = nil
+        tokenProvider: SessionTokenProvider? = nil,
+        errorReporter: any ErrorReporter = ErrorReporting.shared
     ) {
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
@@ -41,6 +43,7 @@ public actor PlaycutMetadataService {
         self.urlSession = .shared
         self.decoder = JSONDecoder()
         self.cache = .Metadata
+        self.errorReporter = errorReporter
     }
 
     // Internal initializer for testing
@@ -49,7 +52,8 @@ public actor PlaycutMetadataService {
         tokenProvider: SessionTokenProvider? = nil,
         session: WebSession,
         urlSession: URLSession = .shared,
-        cache: CacheCoordinator = .Metadata
+        cache: CacheCoordinator = .Metadata,
+        errorReporter: any ErrorReporter = ErrorReporting.shared
     ) {
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
@@ -57,6 +61,7 @@ public actor PlaycutMetadataService {
         self.urlSession = urlSession
         self.decoder = JSONDecoder()
         self.cache = cache
+        self.errorReporter = errorReporter
     }
 
     /// Fetches all available metadata for a playcut using granular caching.
@@ -95,8 +100,12 @@ public actor PlaycutMetadataService {
             return cached
         }
 
-        // Fetch from backend proxy
-        do {
+        return await timedOperation(
+            context: "fetchArtistMetadata(ID: \(artistId))",
+            category: .network,
+            fallback: .empty,
+            errorReporter: errorReporter
+        ) {
             let response = try await fetchFromProxy(
                 path: "proxy/metadata/artist",
                 queryItems: [URLQueryItem(name: "artistId", value: String(artistId))]
@@ -111,9 +120,6 @@ public actor PlaycutMetadataService {
 
             await cache.set(value: metadata, for: cacheKey, lifespan: .thirtyDays)
             return metadata
-        } catch {
-            Log(.error, category: .network, "Failed to fetch artist metadata for ID \(artistId): \(error)")
-            return .empty
         }
     }
 
@@ -137,10 +143,15 @@ public actor PlaycutMetadataService {
             return (album, streaming)
         }
 
-        // Fetch from backend proxy (returns both album metadata and streaming links)
-        Log(.info, category: .network, "Fetching album metadata for: \(playcut.artistName) - \(playcut.releaseTitle ?? "nil")")
+        let fallbackAlbum = cachedAlbum ?? AlbumMetadata(label: playcut.labelName)
+        let fallbackStreaming = cachedStreaming ?? .empty
 
-        do {
+        return await timedOperation(
+            context: "fetchAlbumAndStreaming(\(playcut.artistName))",
+            category: .network,
+            fallback: (fallbackAlbum, fallbackStreaming),
+            errorReporter: errorReporter
+        ) {
             var queryItems = [URLQueryItem(name: "artistName", value: playcut.artistName)]
             if let releaseTitle = playcut.releaseTitle {
                 let title = releaseTitle.lowercased() == "s/t" ? playcut.artistName : releaseTitle
@@ -177,11 +188,6 @@ public actor PlaycutMetadataService {
                 await cache.set(value: streaming, for: streamingCacheKey, lifespan: .sevenDays)
             }
 
-            return (album, streaming)
-        } catch {
-            Log(.error, category: .network, "Failed to fetch album metadata: \(error)")
-            let album = cachedAlbum ?? AlbumMetadata(label: playcut.labelName)
-            let streaming = cachedStreaming ?? .empty
             return (album, streaming)
         }
     }

--- a/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
+++ b/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
@@ -102,31 +102,22 @@ public final class PlaylistFetcher: PlaylistFetcherProtocol, @unchecked Sendable
     /// Fetches a playlist from the remote source.
     /// Returns an empty playlist if the fetch fails.
     public func fetchPlaylist() async -> Playlist {
-        Log(.info, category: .network, "Fetching remote playlist (API \(apiVersion.rawValue))")
         let timer = Core.Timer.start()
-        do {
-            let playlist = try await self.dataSource.getPlaylist()
-            let duration = timer.duration()
-            Log(.info, category: .network, "Remote playlist fetch succeeded: fetch time \(duration), entry count \(playlist.entries.count)")
 
-            // TODO: move to PostHog server-side sampling
-            if Int.random(in: 1...10) == 1 {
-                analytics.capture(FetchPlaylistEvent(duration: duration))
-            }
-
-            return playlist
-        } catch is CancellationError {
-            // Task was cancelled - this is normal during cleanup
-            return Playlist.empty
-        } catch {
-            let duration = timer.duration()
-            errorReporter.report(
-                error,
-                context: "fetchPlaylist",
-                category: .network,
-                additionalData: ["duration": "\(duration)"]
-            )
-            return Playlist.empty
+        let playlist = await timedOperation(
+            context: "fetchPlaylist(API \(apiVersion.rawValue))",
+            category: .network,
+            fallback: .empty,
+            errorReporter: errorReporter
+        ) {
+            try await self.dataSource.getPlaylist()
         }
+
+        // TODO: move to PostHog server-side sampling
+        if playlist != .empty, Int.random(in: 1...10) == 1 {
+            analytics.capture(FetchPlaylistEvent(duration: timer.duration()))
+        }
+
+        return playlist
     }
 }

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistFetcherTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistFetcherTests.swift
@@ -58,7 +58,7 @@ struct PlaylistFetcherTests {
         #expect(result == .empty)
         #expect(mockDataSource.fetchCount == 1)
         #expect(mockErrorReporter.allReportedErrors.count == 1)
-        #expect(mockErrorReporter.allReportedErrors.first?.context == "fetchPlaylist")
+        #expect(mockErrorReporter.allReportedErrors.first?.context == "fetchPlaylist(API v1)")
     }
 
     @Test("fetchPlaylist returns empty playlist on URLError")


### PR DESCRIPTION
## Summary

- Add a generic timedOperation function in Core that encapsulates the common pattern of timing an async operation, logging start/success, handling CancellationError silently, and reporting other errors via ErrorReporter with elapsed duration
- Refactor PlaylistFetcher.fetchPlaylist() to delegate to timedOperation
- Refactor PlaycutMetadataService.fetchArtistMetadata() and fetchAlbumAndStreaming() to delegate to timedOperation, adding CancellationError handling and ErrorReporter integration they were previously missing
- 8 new unit tests for the timedOperation function

Closes #184