### PR TITLE
Extract shared LinkButtonLabel from StreamingButton and ExternalLinkButton

### DIFF
--- a/WXYC.xcodeproj/project.pbxproj
+++ b/WXYC.xcodeproj/project.pbxproj
@@ -182,6 +182,7 @@
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
 				iOS/Tests/WXYCTests/DiscogsFormatterTests.swift,
+				iOS/Tests/WXYCTests/LinkButtonLabelTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingInfoCenterManagerTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingWidgetTests.swift,
 				iOS/Tests/WXYCTests/PlayWXYCIntentTests.swift,
@@ -232,6 +233,7 @@
 				"iOS/Request Share Extension/ShareViewController.swift",
 				iOS/Tests/WXYC.xctestplan,
 				iOS/Tests/WXYCTests/DiscogsFormatterTests.swift,
+				iOS/Tests/WXYCTests/LinkButtonLabelTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingInfoCenterManagerTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingWidgetTests.swift,
 				iOS/Tests/WXYCTests/PlayWXYCIntentTests.swift,

--- a/WXYC/iOS/Tests/WXYCTests/LinkButtonLabelTests.swift
+++ b/WXYC/iOS/Tests/WXYCTests/LinkButtonLabelTests.swift
@@ -1,0 +1,57 @@
+//
+//  LinkButtonLabelTests.swift
+//  WXYC
+//
+//  Tests for LinkButtonLabel, the shared label component used by StreamingButton
+//  and ExternalLinkButton.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import SwiftUI
+@testable import WXYC
+
+@Suite("LinkButtonLabel.Icon Tests")
+struct LinkButtonLabelIconTests {
+
+    @Test("Custom icon stores name and bundle")
+    func customIconProperties() {
+        let icon = LinkButtonLabel.Icon.custom(name: "spotify", bundle: .main)
+
+        switch icon {
+        case .custom(let name, let bundle):
+            #expect(name == "spotify")
+            #expect(bundle == .main)
+        case .system:
+            Issue.record("Expected custom icon")
+        }
+    }
+
+    @Test("System icon stores name")
+    func systemIconProperties() {
+        let icon = LinkButtonLabel.Icon.system(name: "waveform")
+
+        switch icon {
+        case .system(let name):
+            #expect(name == "waveform")
+        case .custom:
+            Issue.record("Expected system icon")
+        }
+    }
+
+    @Test("Custom and system icons are distinct cases")
+    func iconCasesAreDistinct() {
+        let custom = LinkButtonLabel.Icon.custom(name: "test", bundle: .main)
+        let system = LinkButtonLabel.Icon.system(name: "test")
+
+        if case .custom = custom {} else {
+            Issue.record("Expected custom case")
+        }
+
+        if case .system = system {} else {
+            Issue.record("Expected system case")
+        }
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ExternalLinkButton.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ExternalLinkButton.swift
@@ -14,29 +14,21 @@ struct ExternalLinkButton: View {
     let imageName: String
     let url: URL
     var onTap: ((String) -> Void)?
-    
+
     var body: some View {
         Button {
             onTap?(title)
             UIApplication.shared.open(url)
         } label: {
-            HStack(spacing: 12) {
-                Image(imageName, bundle: .playlist)
-                    .resizable()
-                    .aspectRatio(contentMode: .fit)
-                    .frame(width: 20, height: 16)
-                Text(title)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-            }
-            .foregroundStyle(.primary)
-            .frame(maxWidth: .infinity)
-            .padding(.vertical, 12)
-            .background(
-                RoundedRectangle(cornerRadius: 10)
-                    .fill(.primary.opacity(0.15))
+            LinkButtonLabel(
+                icon: .custom(name: imageName, bundle: .playlist),
+                title: title,
+                font: .subheadline,
+                foregroundShapeStyle: AnyShapeStyle(.primary),
+                backgroundFill: AnyShapeStyle(.primary.opacity(0.15)),
+                alignment: .center,
+                spacing: 12
             )
         }
     }
 }
-

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/LinkButtonLabel.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/LinkButtonLabel.swift
@@ -1,0 +1,69 @@
+//
+//  LinkButtonLabel.swift
+//  WXYC
+//
+//  A reusable button label with an icon, title, and rounded rectangle background.
+//  Used by StreamingButton and ExternalLinkButton to share their common layout
+//  structure while allowing each to customize color, font, and icon source.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import SwiftUI
+
+struct LinkButtonLabel: View {
+    let icon: Icon
+    let title: String
+    let font: Font
+    let foregroundShapeStyle: AnyShapeStyle
+    let backgroundFill: AnyShapeStyle
+    let alignment: Alignment
+    let spacing: CGFloat
+
+    var body: some View {
+        HStack(spacing: spacing) {
+            IconView(icon: icon)
+                .frame(width: 20, height: 16)
+            Text(title)
+                .font(font)
+                .fontWeight(.semibold)
+                .lineLimit(1)
+        }
+        .foregroundStyle(foregroundShapeStyle)
+        .frame(maxWidth: .infinity, alignment: alignment)
+        .padding(.vertical, 12)
+        .padding(.horizontal, 12)
+        .background(
+            RoundedRectangle(cornerRadius: 10)
+                .fill(backgroundFill)
+        )
+    }
+}
+
+// MARK: - Icon
+
+extension LinkButtonLabel {
+    enum Icon {
+        case custom(name: String, bundle: Bundle?)
+        case system(name: String)
+    }
+}
+
+// MARK: - Icon View
+
+private struct IconView: View {
+    let icon: LinkButtonLabel.Icon
+
+    var body: some View {
+        switch icon {
+        case .custom(let name, let bundle):
+            Image(name, bundle: bundle)
+                .resizable()
+                .aspectRatio(contentMode: .fit)
+        case .system(let name):
+            Image(systemName: name)
+                .font(.body)
+        }
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/StreamingButton.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/StreamingButton.swift
@@ -16,9 +16,17 @@ struct StreamingButton: View {
     let url: URL?
     let isLoading: Bool
     var onTap: ((StreamingService) -> Void)?
-    
+
     @State private var showingSafari = false
-    
+
+    private var icon: LinkButtonLabel.Icon {
+        if service.hasCustomIcon {
+            .custom(name: service.iconName, bundle: .playlist)
+        } else {
+            .system(name: service.systemIcon)
+        }
+    }
+
     var body: some View {
         Group {
             if let url = url {
@@ -30,45 +38,27 @@ struct StreamingButton: View {
                         UIApplication.shared.open(url)
                     }
                 } label: {
-                    buttonContent
+                    linkLabel(backgroundFill: AnyShapeStyle(service.color))
                 }
                 .sheet(isPresented: $showingSafari) {
                     SafariView(url: url)
                 }
             } else {
-                buttonContent
+                linkLabel(backgroundFill: AnyShapeStyle(service.color.opacity(0.3)))
                     .opacity(isLoading ? 0.5 : 0.3)
             }
         }
     }
-    
-    private var buttonContent: some View {
-        HStack(spacing: 8) {
-            Group {
-                if service.hasCustomIcon {
-                    Image(service.iconName, bundle: .playlist)
-                        .resizable()
-                        .aspectRatio(contentMode: .fit)
-                } else {
-                    Image(systemName: service.systemIcon)
-                        .font(.body)
-                }
-            }
-            .frame(width: 20, height: 16)
-            
-            Text(service.name)
-                .font(.caption)
-                .fontWeight(.semibold)
-                .lineLimit(1)
-        }
-        .foregroundStyle(.white)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .padding(.vertical, 12)
-        .padding(.horizontal, 12)
-        .background(
-            RoundedRectangle(cornerRadius: 10)
-                .fill(service.color.opacity(url != nil ? 1.0 : 0.3))
+
+    private func linkLabel(backgroundFill: AnyShapeStyle) -> some View {
+        LinkButtonLabel(
+            icon: icon,
+            title: service.name,
+            font: .caption,
+            foregroundShapeStyle: AnyShapeStyle(.white),
+            backgroundFill: backgroundFill,
+            alignment: .leading,
+            spacing: 8
         )
     }
 }
-


### PR DESCRIPTION
Closes #186. Both buttons shared nearly identical HStack + icon + text + rounded rect background structure. The new LinkButtonLabel view captures this common layout, parameterized by icon source, font, foreground style, background fill, alignment, and spacing.