### PR TITLE
Extract HTTP status validation into shared extension

### DIFF
--- a/Shared/Core/Sources/Core/Models and Services/HTTPURLResponse+Validation.swift
+++ b/Shared/Core/Sources/Core/Models and Services/HTTPURLResponse+Validation.swift
@@ -1,0 +1,24 @@
+//
+//  HTTPURLResponse+Validation.swift
+//  Core
+//
+//  Extension on HTTPURLResponse providing HTTP status code validation for
+//  success (2xx) responses, replacing duplicated inline checks across packages.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+extension HTTPURLResponse {
+    /// Validates that the HTTP status code is in the 2xx success range.
+    ///
+    /// - Throws: `URLError(.badServerResponse)` if the status code is outside
+    ///   the 200...299 range.
+    public func validateSuccessStatus() throws {
+        guard (200...299).contains(statusCode) else {
+            throw URLError(.badServerResponse)
+        }
+    }
+}

--- a/Shared/Core/Sources/Core/Models and Services/URLSession+WebSession.swift
+++ b/Shared/Core/Sources/Core/Models and Services/URLSession+WebSession.swift
@@ -14,10 +14,7 @@ extension URLSession: WebSession {
     public func data(from url: URL) async throws -> Data {
         let (data, response) = try await data(from: url)
 
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200...299).contains(httpResponse.statusCode) {
-            throw URLError(.badServerResponse)
-        }
+        try (response as? HTTPURLResponse)?.validateSuccessStatus()
 
         return data
     }

--- a/Shared/Core/Tests/CoreTests/HTTPURLResponseValidationTests.swift
+++ b/Shared/Core/Tests/CoreTests/HTTPURLResponseValidationTests.swift
@@ -1,0 +1,60 @@
+//
+//  HTTPURLResponseValidationTests.swift
+//  Core
+//
+//  Tests for HTTPURLResponse.validateSuccessStatus() extension.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Core
+
+@Suite
+struct HTTPURLResponseValidationTests {
+    private static let testURL = URL(string: "https://api.wxyc.org/flowsheet")!
+
+    @Test(arguments: [200, 201, 204, 299])
+    func successStatusCodesDoNotThrow(statusCode: Int) throws {
+        let response = HTTPURLResponse(
+            url: HTTPURLResponseValidationTests.testURL,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        #expect(throws: Never.self) {
+            try response.validateSuccessStatus()
+        }
+    }
+
+    @Test(arguments: [100, 199, 300, 400, 404, 500, 503])
+    func nonSuccessStatusCodesThrow(statusCode: Int) throws {
+        let response = HTTPURLResponse(
+            url: HTTPURLResponseValidationTests.testURL,
+            statusCode: statusCode,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        #expect(throws: URLError.self) {
+            try response.validateSuccessStatus()
+        }
+    }
+
+    @Test
+    func thrownErrorIsBadServerResponse() throws {
+        let response = HTTPURLResponse(
+            url: HTTPURLResponseValidationTests.testURL,
+            statusCode: 500,
+            httpVersion: nil,
+            headerFields: nil
+        )!
+        #expect {
+            try response.validateSuccessStatus()
+        } throws: { error in
+            let urlError = error as? URLError
+            return urlError?.code == .badServerResponse
+        }
+    }
+}

--- a/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
+++ b/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
@@ -207,10 +207,7 @@ public actor PlaycutMetadataService {
             var request = URLRequest(url: url)
             request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
             let (data, response) = try await urlSession.data(for: request)
-            if let httpResponse = response as? HTTPURLResponse,
-               !(200...299).contains(httpResponse.statusCode) {
-                throw MetadataError.httpError(statusCode: httpResponse.statusCode)
-            }
+            try (response as? HTTPURLResponse)?.validateSuccessStatus()
             return data
         } else {
             return try await session.data(from: url)

--- a/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
+++ b/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
@@ -33,10 +33,7 @@ private let decoder = JSONDecoder()
 extension URLSession: PlaylistDataSource {
     public func getPlaylist() async throws -> Playlist {
         let (playlistData, response) = try await self.data(from: URL.WXYCPlaylist)
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200...299).contains(httpResponse.statusCode) {
-            throw URLError(.badServerResponse)
-        }
+        try (response as? HTTPURLResponse)?.validateSuccessStatus()
         let repairedData = playlistData.repairingMojibake()
         return try decoder.decode(Playlist.self, from: repairedData)
     }

--- a/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
@@ -9,6 +9,7 @@
 //
 
 import Foundation
+import Core
 
 /// URL for the v2 flowsheet API.
 extension URL {
@@ -25,10 +26,7 @@ public final class PlaylistDataSourceV2: PlaylistDataSource, @unchecked Sendable
 
     public func getPlaylist() async throws -> Playlist {
         let (data, response) = try await session.data(from: URL.WXYCFlowsheet)
-        if let httpResponse = response as? HTTPURLResponse,
-           !(200...299).contains(httpResponse.statusCode) {
-            throw URLError(.badServerResponse)
-        }
+        try (response as? HTTPURLResponse)?.validateSuccessStatus()
         let decoder = JSONDecoder()
         let entries = try decoder.decode([FlowsheetEntry].self, from: data)
         return FlowsheetConverter.convert(entries)


### PR DESCRIPTION
## Summary

- Extract the duplicated HTTP 2xx status code validation pattern into a shared `HTTPURLResponse.validateSuccessStatus()` extension in the Core package
- Replace 4 inline occurrences across Core, Playlist, and Metadata packages with calls to the new method
- Add parameterized tests for success codes, failure codes, and error type verification

Closes #188

## Test plan

- [x] New `HTTPURLResponseValidationTests` suite covers success (200, 201, 204, 299) and failure (100, 199, 300, 400, 404, 500, 503) status codes
- [x] Existing `PlaycutMetadataServiceHTTPTests` continue to pass (verify fallback behavior on non-2xx)
- [x] Full test plan passes (80 tests in 11 suites)
