### PR TITLE
Extract generic cachedFetch utility

### DIFF
--- a/Shared/Caching/Sources/Caching/CachedFetch.swift
+++ b/Shared/Caching/Sources/Caching/CachedFetch.swift
@@ -1,0 +1,157 @@
+//
+//  CachedFetch.swift
+//  Caching
+//
+//  Generic fetch-and-cache utility that encapsulates the check-cache, fetch,
+//  decode, store, and fallback workflow. Eliminates duplicated boilerplate
+//  across services that follow this pattern.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Fetches a `Codable` value using a check-cache-then-fetch workflow.
+///
+/// This function encapsulates a pattern repeated across many services:
+/// 1. Check the cache for an existing value
+/// 2. On miss, call the `fetch` closure to obtain a raw value
+/// 3. Transform the raw value into the cached type
+/// 4. Store the result in the cache with the specified lifespan
+/// 5. On error, return a fallback value
+///
+/// ## Usage
+///
+/// ```swift
+/// let metadata: ArtistMetadata = try await cachedFetch(
+///     key: "artist-123",
+///     cache: cache,
+///     lifespan: .thirtyDays,
+///     fetch: { try await api.fetchArtist(id: 123) },
+///     transform: { ArtistMetadata(bio: $0.bio, url: $0.url) },
+///     fallback: { .empty }
+/// )
+/// ```
+///
+/// - Parameters:
+///   - key: The cache key for storage and retrieval.
+///   - cache: The ``CacheCoordinator`` to use for caching.
+///   - lifespan: How long the cached entry should remain valid, in seconds.
+///   - fetch: An async throwing closure that fetches the raw value from the network or other source.
+///   - transform: A closure that transforms the fetched value into the cached type.
+///   - fallback: A closure that provides a fallback value when both cache lookup and fetch fail.
+/// - Returns: The cached, fetched, or fallback value.
+public func cachedFetch<Fetched: Codable & Sendable, Cached: Codable & Sendable>(
+    key: String,
+    cache: CacheCoordinator,
+    lifespan: TimeInterval,
+    fetch: sending () async throws -> Fetched,
+    transform: sending (Fetched) throws -> Cached,
+    fallback: sending () -> Cached
+) async throws -> Cached {
+    if let cached: Cached = try? await cache.value(for: key) {
+        return cached
+    }
+
+    do {
+        let raw = try await fetch()
+        let result = try transform(raw)
+        await cache.set(value: result, for: key, lifespan: lifespan)
+        return result
+    } catch {
+        return fallback()
+    }
+}
+
+/// Fetches a `Codable` value using a check-cache-then-fetch workflow, propagating errors.
+///
+/// Same as the fallback variant, but errors from `fetch` or `transform` are propagated
+/// to the caller instead of being caught.
+///
+/// ## Usage
+///
+/// ```swift
+/// let name: String = try await cachedFetch(
+///     key: "artist-123",
+///     cache: cache,
+///     lifespan: .thirtyDays,
+///     fetch: { try await api.fetchArtistName(id: 123) },
+///     transform: { $0.name }
+/// )
+/// ```
+///
+/// - Parameters:
+///   - key: The cache key for storage and retrieval.
+///   - cache: The ``CacheCoordinator`` to use for caching.
+///   - lifespan: How long the cached entry should remain valid, in seconds.
+///   - fetch: An async throwing closure that fetches the raw value from the network or other source.
+///   - transform: A closure that transforms the fetched value into the cached type.
+/// - Returns: The cached or fetched value.
+/// - Throws: The error from `fetch` or `transform`.
+public func cachedFetch<Fetched: Codable & Sendable, Cached: Codable & Sendable>(
+    key: String,
+    cache: CacheCoordinator,
+    lifespan: TimeInterval,
+    fetch: sending () async throws -> Fetched,
+    transform: sending (Fetched) throws -> Cached
+) async throws -> Cached {
+    if let cached: Cached = try? await cache.value(for: key) {
+        return cached
+    }
+
+    let raw = try await fetch()
+    let result = try transform(raw)
+    await cache.set(value: result, for: key, lifespan: lifespan)
+    return result
+}
+
+/// Convenience overload when the fetched type is the same as the cached type (no transform needed).
+///
+/// - Parameters:
+///   - key: The cache key for storage and retrieval.
+///   - cache: The ``CacheCoordinator`` to use for caching.
+///   - lifespan: How long the cached entry should remain valid, in seconds.
+///   - fetch: An async throwing closure that fetches the value.
+///   - fallback: A closure providing a fallback value on failure.
+/// - Returns: The cached, fetched, or fallback value.
+public func cachedFetch<Value: Codable & Sendable>(
+    key: String,
+    cache: CacheCoordinator,
+    lifespan: TimeInterval,
+    fetch: sending () async throws -> Value,
+    fallback: sending () -> Value
+) async throws -> Value {
+    try await cachedFetch(
+        key: key,
+        cache: cache,
+        lifespan: lifespan,
+        fetch: fetch,
+        transform: { $0 },
+        fallback: fallback
+    )
+}
+
+/// Convenience overload when the fetched type is the same as the cached type and errors should propagate.
+///
+/// - Parameters:
+///   - key: The cache key for storage and retrieval.
+///   - cache: The ``CacheCoordinator`` to use for caching.
+///   - lifespan: How long the cached entry should remain valid, in seconds.
+///   - fetch: An async throwing closure that fetches the value.
+/// - Returns: The cached or fetched value.
+/// - Throws: The error from `fetch`.
+public func cachedFetch<Value: Codable & Sendable>(
+    key: String,
+    cache: CacheCoordinator,
+    lifespan: TimeInterval,
+    fetch: sending () async throws -> Value
+) async throws -> Value {
+    try await cachedFetch(
+        key: key,
+        cache: cache,
+        lifespan: lifespan,
+        fetch: fetch,
+        transform: { $0 }
+    )
+}

--- a/Shared/Caching/Tests/CachingTests/CachedFetchTests.swift
+++ b/Shared/Caching/Tests/CachingTests/CachedFetchTests.swift
@@ -1,0 +1,271 @@
+//
+//  CachedFetchTests.swift
+//  Caching
+//
+//  Tests for the CachedFetch utility that encapsulates the check-cache, fetch,
+//  decode, store, and fallback workflow used across multiple services.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import Caching
+
+// MARK: - CachedFetch Tests
+
+@Suite("CachedFetch Tests")
+struct CachedFetchTests {
+
+    // MARK: - Cache Hit
+
+    @Test("Returns cached value without calling fetch closure")
+    func returnsCachedValueWithoutFetch() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+        await cache.set(value: "cached result", for: "key", lifespan: 3600)
+        var fetchCalled = false
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: {
+                fetchCalled = true
+                return "fetched result"
+            }
+        )
+
+        // Then
+        #expect(result == "cached result")
+        #expect(!fetchCalled)
+    }
+
+    // MARK: - Cache Miss
+
+    @Test("Fetches and caches value on cache miss")
+    func fetchesAndCachesOnMiss() async throws {
+        // Given
+        let mockCache = MockCache()
+        let cache = CacheCoordinator(cache: mockCache)
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { "fetched result" }
+        )
+
+        // Then
+        #expect(result == "fetched result")
+        let cached: String = try await cache.value(for: "key")
+        #expect(cached == "fetched result")
+    }
+
+    // MARK: - Fetch Error Propagation
+
+    @Test("Propagates fetch errors when no fallback is provided")
+    func propagatesFetchErrors() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When/Then
+        await #expect(throws: TestFetchError.networkFailure) {
+            let _: String = try await cachedFetch(
+                key: "key",
+                cache: cache,
+                lifespan: 3600,
+                fetch: { throw TestFetchError.networkFailure }
+            )
+        }
+    }
+
+    // MARK: - Fallback on Error
+
+    @Test("Returns fallback value when fetch fails")
+    func returnsFallbackOnFetchError() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { throw TestFetchError.networkFailure },
+            fallback: { "fallback value" }
+        )
+
+        // Then
+        #expect(result == "fallback value")
+    }
+
+    @Test("Does not cache fallback values")
+    func doesNotCacheFallbackValues() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When
+        let _: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { throw TestFetchError.networkFailure },
+            fallback: { "fallback value" }
+        )
+
+        // Then
+        await #expect(throws: CacheCoordinator.Error.noCachedResult) {
+            let _: String = try await cache.value(for: "key")
+        }
+    }
+
+    // MARK: - Transform
+
+    @Test("Applies transform to fetched value before caching")
+    func appliesTransformBeforeCaching() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { "  raw value  " },
+            transform: { $0.trimmingCharacters(in: .whitespaces) }
+        )
+
+        // Then
+        #expect(result == "raw value")
+        let cached: String = try await cache.value(for: "key")
+        #expect(cached == "raw value")
+    }
+
+    // MARK: - Expired Cache
+
+    @Test("Fetches fresh value when cache entry has expired")
+    func fetchesFreshValueOnExpiredCache() async throws {
+        // Given
+        let mockClock = MockClock()
+        let cache = CacheCoordinator(cache: MockCache(), clock: mockClock)
+        await cache.set(value: "stale", for: "key", lifespan: 60)
+        mockClock.advance(by: 61)
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 60,
+            fetch: { "fresh" }
+        )
+
+        // Then
+        #expect(result == "fresh")
+    }
+
+    // MARK: - Custom Codable Types
+
+    @Test("Works with custom Codable structs")
+    func worksWithCustomCodableStructs() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+        let expected = CachedPerson(name: "Juana Molina", age: 62)
+
+        // When
+        let result: CachedPerson = try await cachedFetch(
+            key: "person",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { expected }
+        )
+
+        // Then
+        #expect(result == expected)
+    }
+
+    // MARK: - Different Fetch and Cache Types
+
+    @Test("Transforms fetched type to a different cached type")
+    func transformsFetchedTypeToDifferentCachedType() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+        let rawResponse = RawAPIResponse(value: "42", label: "answer")
+
+        // When
+        let result: ParsedResult = try await cachedFetch(
+            key: "parsed",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { rawResponse },
+            transform: { ParsedResult(number: Int($0.value) ?? 0, label: $0.label) }
+        )
+
+        // Then
+        #expect(result.number == 42)
+        #expect(result.label == "answer")
+    }
+
+    // MARK: - Fallback with Transform and Error
+
+    @Test("Returns fallback when transform throws")
+    func returnsFallbackWhenTransformThrows() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When
+        let result: String = try await cachedFetch(
+            key: "key",
+            cache: cache,
+            lifespan: 3600,
+            fetch: { "raw" },
+            transform: { (_: String) -> String in throw TestFetchError.transformFailure },
+            fallback: { "fallback" }
+        )
+
+        // Then
+        #expect(result == "fallback")
+    }
+
+    @Test("Propagates transform error when no fallback provided")
+    func propagatesTransformErrorWhenNoFallback() async throws {
+        // Given
+        let cache = CacheCoordinator(cache: MockCache())
+
+        // When/Then
+        await #expect(throws: TestFetchError.transformFailure) {
+            let _: String = try await cachedFetch(
+                key: "key",
+                cache: cache,
+                lifespan: 3600,
+                fetch: { "raw" },
+                transform: { (_: String) -> String in throw TestFetchError.transformFailure }
+            )
+        }
+    }
+}
+
+// MARK: - Test Helpers
+
+private enum TestFetchError: Error {
+    case networkFailure
+    case transformFailure
+}
+
+private struct CachedPerson: Codable, Equatable, Sendable {
+    let name: String
+    let age: Int
+}
+
+private struct RawAPIResponse: Codable, Sendable {
+    let value: String
+    let label: String
+}
+
+private struct ParsedResult: Codable, Equatable, Sendable {
+    let number: Int
+    let label: String
+}

--- a/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
+++ b/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
@@ -61,38 +61,36 @@ public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
     private func resolve(type: String, id: Int) async throws -> String {
         let cacheKey = MetadataCacheKey.discogsEntity(type: type, id: id)
 
-        // Check cache first
-        if let cached: String = try? await cache.value(for: cacheKey) {
-            return cached
-        }
+        return try await cachedFetch(
+            key: cacheKey,
+            cache: cache,
+            lifespan: Self.cacheLifespan,
+            fetch: {
+                var components = URLComponents(url: baseURL.appending(path: "proxy/entity/resolve"), resolvingAgainstBaseURL: false)!
+                components.queryItems = [
+                    URLQueryItem(name: "type", value: type),
+                    URLQueryItem(name: "id", value: String(id))
+                ]
 
-        var components = URLComponents(url: baseURL.appending(path: "proxy/entity/resolve"), resolvingAgainstBaseURL: false)!
-        components.queryItems = [
-            URLQueryItem(name: "type", value: type),
-            URLQueryItem(name: "id", value: String(id))
-        ]
+                guard let url = components.url else {
+                    throw ServiceError.noResults
+                }
 
-        guard let url = components.url else {
-            throw ServiceError.noResults
-        }
+                let data: Data
+                if let tokenProvider {
+                    let token = try await tokenProvider.token()
+                    var request = URLRequest(url: url)
+                    request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+                    let (responseData, _) = try await URLSession.shared.data(for: request)
+                    data = responseData
+                } else {
+                    data = try await session.data(from: url)
+                }
 
-        let data: Data
-        if let tokenProvider {
-            let token = try await tokenProvider.token()
-            var request = URLRequest(url: url)
-            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
-            let (responseData, _) = try await URLSession.shared.data(for: request)
-            data = responseData
-        } else {
-            data = try await session.data(from: url)
-        }
-
-        let response = try decoder.decode(EntityResolveResponse.self, from: data)
-
-        // Cache the result
-        await cache.set(value: response.name, for: cacheKey, lifespan: Self.cacheLifespan)
-
-        return response.name
+                return try decoder.decode(EntityResolveResponse.self, from: data)
+            },
+            transform: { $0.name }
+        )
     }
 }
 

--- a/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
+++ b/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
@@ -94,33 +94,25 @@ public actor PlaycutMetadataService {
 
         let cacheKey = MetadataCacheKey.artist(discogsId: artistId)
 
-        // Check cache
-        if let cached: ArtistMetadata = try? await cache.value(for: cacheKey) {
-            Log(.info, category: .network, "Artist metadata cache hit for ID \(artistId)")
-            return cached
-        }
-
-        return await timedOperation(
-            context: "fetchArtistMetadata(ID: \(artistId))",
-            category: .network,
-            fallback: .empty,
-            errorReporter: errorReporter
-        ) {
-            let response = try await fetchFromProxy(
-                path: "proxy/metadata/artist",
-                queryItems: [URLQueryItem(name: "artistId", value: String(artistId))]
-            )
-
-            let apiResult = try decoder.decode(ArtistMetadataAPIResponse.self, from: response)
-            let metadata = ArtistMetadata(
-                bio: apiResult.bio,
-                wikipediaURL: apiResult.wikipediaUrl.flatMap { URL(string: $0) },
-                discogsArtistId: apiResult.discogsArtistId ?? artistId
-            )
-
-            await cache.set(value: metadata, for: cacheKey, lifespan: .thirtyDays)
-            return metadata
-        }
+        return (try? await cachedFetch(
+            key: cacheKey,
+            cache: cache,
+            lifespan: .thirtyDays,
+            fetch: {
+                let response = try await fetchFromProxy(
+                    path: "proxy/metadata/artist",
+                    queryItems: [URLQueryItem(name: "artistId", value: String(artistId))]
+                )
+                return try decoder.decode(ArtistMetadataAPIResponse.self, from: response)
+            },
+            transform: { apiResult in
+                ArtistMetadata(
+                    bio: apiResult.bio,
+                    wikipediaURL: apiResult.wikipediaUrl.flatMap { URL(string: $0) },
+                    discogsArtistId: apiResult.discogsArtistId ?? artistId
+                )
+            }
+        )) ?? .empty
     }
 
     /// Fetches album metadata and streaming links from the backend proxy in a single call.


### PR DESCRIPTION
## Summary
- Add a generic cachedFetch function to the Caching package that encapsulates the check-cache/fetch/decode/transform/store/fallback workflow
- Refactor DiscogsAPIEntityResolver.resolve() and PlaycutMetadataService.fetchArtistMetadata() to use it
- 11 new unit tests covering cache hit, miss, error propagation, fallback, transform, expired cache, and custom types

Closes #190

## Test plan
- [x] CachedFetchTests (11 tests) all pass
- [x] MetadataTests (all existing tests) continue to pass
- [x] Full project builds successfully
