### PR TITLE
Replace redundant JSONDecoder allocations with JSONDecoder.shared

### DIFF
--- a/Shared/AppServices/Sources/AppServices/AppConfiguration.swift
+++ b/Shared/AppServices/Sources/AppServices/AppConfiguration.swift
@@ -85,7 +85,7 @@ public actor AppConfiguration {
                 return Self.defaults
             }
 
-            let config = try JSONDecoder().decode(AppConfig.self, from: data)
+            let config = try JSONDecoder.shared.decode(AppConfig.self, from: data)
             cached = config
             return config
         } catch {
@@ -113,7 +113,7 @@ public actor AppConfiguration {
                 return nil
             }
 
-            return try JSONDecoder().decode(AppSecrets.self, from: data)
+            return try JSONDecoder.shared.decode(AppSecrets.self, from: data)
         } catch {
             Log(.warning, category: .general, "AppConfiguration: failed to fetch /config/secrets: \(error.localizedDescription)")
             return nil

--- a/Shared/Artwork/Sources/Artwork/DiscogsArtworkService.swift
+++ b/Shared/Artwork/Sources/Artwork/DiscogsArtworkService.swift
@@ -24,7 +24,6 @@ public final class DiscogsArtworkService: ArtworkService {
     private let key: String
     private let secret: String
     private let session: WebSession
-    private let decoder = JSONDecoder()
 
     public init(key: String, secret: String, session: WebSession = URLSession.shared) {
         self.key = key
@@ -102,7 +101,7 @@ public final class DiscogsArtworkService: ArtworkService {
     
     func fetchArtURL(for searchURL: URL) async throws -> URL? {
         let searchData = try await session.data(from: searchURL)
-        let searchResponse = try decoder.decode(Discogs.SearchResults.self, from: searchData)
+        let searchResponse = try JSONDecoder.shared.decode(Discogs.SearchResults.self, from: searchData)
         
         let imageURLs: [URL] = searchResponse.results.map(\.coverImage)
         return imageURLs.first(where: { !$0.lastPathComponent.hasPrefix("spacer.gif") })

--- a/Shared/Caching/Sources/Caching/CacheCoordinator.swift
+++ b/Shared/Caching/Sources/Caching/CacheCoordinator.swift
@@ -9,6 +9,7 @@
 //  Copyright © 2018 WXYC. All rights reserved.
 //
 
+import Core
 import Foundation
 import Logger
 
@@ -127,7 +128,7 @@ public final actor CacheCoordinator {
     private static let encoder = JSONEncoder()
 
     /// Shared JSON decoder for deserializing Codable values.
-    private static let decoder = JSONDecoder()
+    private static let decoder = JSONDecoder.shared
 
     // MARK: - Binary Data Operations
 

--- a/Shared/Caching/Sources/Caching/DiskCache.swift
+++ b/Shared/Caching/Sources/Caching/DiskCache.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2018 WXYC. All rights reserved.
 //
 
+import Core
 import Foundation
 import Logger
 
@@ -162,7 +163,7 @@ struct DiskCache: Cache, @unchecked Sendable {
             guard result == size else { return nil }
 
             // Decode the JSON-encoded metadata
-            return try? JSONDecoder().decode(CacheMetadata.self, from: data)
+            return try? JSONDecoder.shared.decode(CacheMetadata.self, from: data)
         }
     }
 

--- a/Shared/Core/Sources/Core/JSONDecoder+Shared.swift
+++ b/Shared/Core/Sources/Core/JSONDecoder+Shared.swift
@@ -1,0 +1,23 @@
+//
+//  JSONDecoder+Shared.swift
+//  Core
+//
+//  Provides a shared default-configured JSONDecoder instance to avoid redundant allocations.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+extension JSONDecoder {
+    /// A shared `JSONDecoder` instance with default configuration.
+    ///
+    /// Use this instead of creating a new `JSONDecoder()` when no custom configuration
+    /// (date strategy, key decoding strategy, etc.) is needed. Because this instance is
+    /// never mutated after creation, it is safe for concurrent use across threads.
+    ///
+    /// - Important: Do not mutate this decoder. If you need custom configuration,
+    ///   create a new `JSONDecoder()` instead.
+    public static let shared = JSONDecoder()
+}

--- a/Shared/Core/Tests/CoreTests/JSONDecoderSharedTests.swift
+++ b/Shared/Core/Tests/CoreTests/JSONDecoderSharedTests.swift
@@ -1,0 +1,44 @@
+//
+//  JSONDecoderSharedTests.swift
+//  Core
+//
+//  Tests for the JSONDecoder.shared static property.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import Core
+
+@Suite
+struct JSONDecoderSharedTests {
+    @Test
+    func sharedReturnsAJSONDecoder() {
+        let decoder = JSONDecoder.shared
+        #expect(decoder is JSONDecoder)
+    }
+
+    @Test
+    func sharedReturnsSameInstance() {
+        let first = JSONDecoder.shared
+        let second = JSONDecoder.shared
+        #expect(first === second)
+    }
+
+    @Test
+    func sharedDecodesJSON() throws {
+        let json = #"{"name":"Autechre","album":"Confield"}"#.data(using: .utf8)!
+        let result = try JSONDecoder.shared.decode(TestModel.self, from: json)
+        #expect(result.name == "Autechre")
+        #expect(result.album == "Confield")
+    }
+}
+
+// MARK: - Test Helpers
+
+private struct TestModel: Codable {
+    let name: String
+    let album: String
+}

--- a/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
+++ b/Shared/Metadata/Sources/Metadata/DiscogsEntityResolver.swift
@@ -24,7 +24,6 @@ public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
     private let baseURL: URL
     private let tokenProvider: SessionTokenProvider?
     private let session: WebSession
-    private let decoder: JSONDecoder
     private let cache: CacheCoordinator
 
     /// Cache lifespan: 30 days (entity names essentially never change)
@@ -42,7 +41,6 @@ public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
         self.baseURL = baseURL
         self.tokenProvider = tokenProvider
         self.session = session
-        self.decoder = JSONDecoder()
         self.cache = cache
     }
 
@@ -87,7 +85,7 @@ public final class DiscogsAPIEntityResolver: DiscogsEntityResolver, Sendable {
                     data = try await session.data(from: url)
                 }
 
-                return try decoder.decode(EntityResolveResponse.self, from: data)
+                return try JSONDecoder.shared.decode(EntityResolveResponse.self, from: data)
             },
             transform: { $0.name }
         )

--- a/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
+++ b/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
@@ -28,7 +28,6 @@ public actor PlaycutMetadataService {
     private let tokenProvider: SessionTokenProvider?
     private let session: WebSession
     private let urlSession: URLSession
-    private let decoder: JSONDecoder
     private let cache: CacheCoordinator
     private let errorReporter: any ErrorReporter
 
@@ -41,7 +40,6 @@ public actor PlaycutMetadataService {
         self.tokenProvider = tokenProvider
         self.session = URLSession.shared
         self.urlSession = .shared
-        self.decoder = JSONDecoder()
         self.cache = .Metadata
         self.errorReporter = errorReporter
     }
@@ -59,7 +57,6 @@ public actor PlaycutMetadataService {
         self.tokenProvider = tokenProvider
         self.session = session
         self.urlSession = urlSession
-        self.decoder = JSONDecoder()
         self.cache = cache
         self.errorReporter = errorReporter
     }
@@ -103,7 +100,7 @@ public actor PlaycutMetadataService {
                     path: "proxy/metadata/artist",
                     queryItems: [URLQueryItem(name: "artistId", value: String(artistId))]
                 )
-                return try decoder.decode(ArtistMetadataAPIResponse.self, from: response)
+                return try JSONDecoder.shared.decode(ArtistMetadataAPIResponse.self, from: response)
             },
             transform: { apiResult in
                 ArtistMetadata(
@@ -152,7 +149,7 @@ public actor PlaycutMetadataService {
             queryItems.append(URLQueryItem(name: "trackTitle", value: playcut.songTitle))
 
             let data = try await fetchFromProxy(path: "proxy/metadata/album", queryItems: queryItems)
-            let apiResult = try decoder.decode(AlbumMetadataAPIResponse.self, from: data)
+            let apiResult = try JSONDecoder.shared.decode(AlbumMetadataAPIResponse.self, from: data)
 
             let album = cachedAlbum ?? AlbumMetadata(
                 label: apiResult.label ?? playcut.labelName,

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthNetworkClient.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthNetworkClient.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2026 WXYC. All rights reserved.
 //
 
+import Core
 import Foundation
 
 /// Protocol for making authentication network requests.
@@ -63,7 +64,7 @@ public struct DefaultAuthNetworkClient: AuthNetworkClient {
         }
 
         do {
-            let authResponse = try JSONDecoder().decode(AuthResponse.self, from: response.data)
+            let authResponse = try JSONDecoder.shared.decode(AuthResponse.self, from: response.data)
             return AuthSession(
                 token: authResponse.token,
                 userId: authResponse.user.id,

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
@@ -9,6 +9,7 @@
 //
 
 import Analytics
+import Core
 import Foundation
 import Security
 
@@ -68,7 +69,7 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
                 throw AuthenticationError.keychainError(status: errSecParam)
             }
             do {
-                let session = try JSONDecoder().decode(AuthSession.self, from: data)
+                let session = try JSONDecoder.shared.decode(AuthSession.self, from: data)
                 return session
             } catch {
                 trackKeychainError(operation: .read, status: errSecDecode)

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Services/SpotifyService.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Services/SpotifyService.swift
@@ -8,6 +8,7 @@
 //  Copyright © 2025 WXYC. All rights reserved.
 //
 
+import Core
 import Foundation
 
 enum SpotifyError: Error {
@@ -114,7 +115,7 @@ final class SpotifyService: MusicService {
             throw SpotifyError.trackNotFound
         }
 
-        let json = try JSONDecoder().decode(SpotifyTrackProxyResponse.self, from: data)
+        let json = try JSONDecoder.shared.decode(SpotifyTrackProxyResponse.self, from: data)
 
         return MusicTrack(
             service: track.service,

--- a/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
+++ b/Shared/Playlist/Sources/Playlist/PlaylistFetcher.swift
@@ -28,14 +28,12 @@ public protocol PlaylistDataSource: Sendable {
 
 // MARK: - URLSession Playlist Fetching
 
-private let decoder = JSONDecoder()
-
 extension URLSession: PlaylistDataSource {
     public func getPlaylist() async throws -> Playlist {
         let (playlistData, response) = try await self.data(from: URL.WXYCPlaylist)
         try (response as? HTTPURLResponse)?.validateSuccessStatus()
         let repairedData = playlistData.repairingMojibake()
-        return try decoder.decode(Playlist.self, from: repairedData)
+        return try JSONDecoder.shared.decode(Playlist.self, from: repairedData)
     }
 }
 

--- a/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
@@ -27,8 +27,7 @@ public final class PlaylistDataSourceV2: PlaylistDataSource, @unchecked Sendable
     public func getPlaylist() async throws -> Playlist {
         let (data, response) = try await session.data(from: URL.WXYCFlowsheet)
         try (response as? HTTPURLResponse)?.validateSuccessStatus()
-        let decoder = JSONDecoder()
-        let entries = try decoder.decode([FlowsheetEntry].self, from: data)
+        let entries = try JSONDecoder.shared.decode([FlowsheetEntry].self, from: data)
         return FlowsheetConverter.convert(entries)
     }
 }


### PR DESCRIPTION
## Summary
- Add `JSONDecoder.shared` static property in Core for default-configured decoding
- Replace 11 call sites across 6 packages (Playlist, Metadata, Artwork, Caching, MusicShareKit, AppServices)
- 3 tests verifying identity, type, and decode behavior

Closes #193