### PR TITLE
Extract shared test utilities from duplicated mock boilerplate

### DIFF
--- a/Shared/Analytics/Sources/AnalyticsTesting/MockFeatureFlagProvider.swift
+++ b/Shared/Analytics/Sources/AnalyticsTesting/MockFeatureFlagProvider.swift
@@ -1,0 +1,33 @@
+//
+//  MockFeatureFlagProvider.swift
+//  AnalyticsTesting
+//
+//  Test double for FeatureFlagProvider that returns configurable flag values.
+//  Replaces the identical MockFeatureFlagProvider classes scattered across test targets.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Analytics
+
+/// Test double for ``FeatureFlagProvider`` that returns configurable flag values.
+///
+/// Set flag values via the ``flags`` dictionary, then inject this provider
+/// into the code under test.
+///
+/// ```swift
+/// let provider = MockFeatureFlagProvider()
+/// provider.flags["my_feature"] = true
+/// let enabled = MyFeature.isEnabled(featureFlagProvider: provider)
+/// ```
+public final class MockFeatureFlagProvider: FeatureFlagProvider {
+    /// The flag values to return from ``getFeatureFlag(_:)``.
+    public var flags: [String: Any] = [:]
+
+    public init() {}
+
+    public func getFeatureFlag(_ key: String) -> Any? {
+        flags[key]
+    }
+}

--- a/Shared/AppServices/Package.swift
+++ b/Shared/AppServices/Package.swift
@@ -35,6 +35,7 @@ let package = Package(
                 "AppServices",
                 "Caching",
                 "Playlist",
+                .product(name: "PlaylistTesting", package: "Playlist"),
                 "Artwork",
                 .product(name: "PlaybackCore", package: "Playback"),
             ]

--- a/Shared/AppServices/Tests/AppServicesTests/NowPlayingServiceTests.swift
+++ b/Shared/AppServices/Tests/AppServicesTests/NowPlayingServiceTests.swift
@@ -13,84 +13,19 @@ import Foundation
 import Artwork
 import Core
 import ImageIO
+import PlaylistTesting
 @testable import Playlist
 @testable import AppServices
 @testable import Caching
 
-// MARK: - Mock Types
+// MARK: - Helpers
 
-final class MockPlaylistFetcher: PlaylistFetcherProtocol, @unchecked Sendable {
-    var playlistToReturn: Playlist = .empty
-    var callCount = 0
-
-    func fetchPlaylist() async -> Playlist {
-        callCount += 1
-        return playlistToReturn
-    }
-}
-
-// MARK: - Mock Cache for Isolated Tests
-
-/// In-memory cache for isolated test execution
-final class NowPlayingTestMockCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-    private let lock = NSLock()
-
-    func metadata(for key: String) -> CacheMetadata? {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage[key]
-    }
-    
-    func data(for key: String) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage[key]
-    }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        if let data = data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-    
-    func remove(for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-
-    func totalSize() -> Int64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
-
-/// Helper to create an isolated cache coordinator for testing
+/// Helper to create an isolated cache coordinator for testing.
 func makeNowPlayingTestCacheCoordinator() -> CacheCoordinator {
-    CacheCoordinator(cache: NowPlayingTestMockCache())
+    CacheCoordinator(cache: InMemoryCache())
 }
+
+// MARK: - Mock Types
 
 final class MockArtworkService: ArtworkService, @unchecked Sendable {
     var artworkToReturn: CGImage?
@@ -122,48 +57,6 @@ final class MockArtworkService: ArtworkService, @unchecked Sendable {
 
 enum ArtworkServiceError: Error {
     case noResults
-}
-
-// MARK: - Playcut Test Stub
-
-extension Playcut {
-    /// Creates a Playcut with sensible defaults for testing.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil,
-        songTitle: String = "Test Song",
-        labelName: String? = nil,
-        artistName: String = "Test Artist",
-        releaseTitle: String? = nil
-    ) -> Playcut {
-        Playcut(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour,
-            songTitle: songTitle,
-            labelName: labelName,
-            artistName: artistName,
-            releaseTitle: releaseTitle
-        )
-    }
-}
-
-extension Playlist {
-    /// Creates a Playlist stub for testing.
-    static func stub(
-        playcuts: [Playcut] = [],
-        breakpoints: [Breakpoint] = [],
-        talksets: [Talkset] = []
-    ) -> Playlist {
-        Playlist(
-            playcuts: playcuts,
-            breakpoints: breakpoints,
-            talksets: talksets
-        )
-    }
 }
 
 // MARK: - Tests

--- a/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
+++ b/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
@@ -12,11 +12,12 @@
 #if canImport(WidgetKit)
 import AppIntents
 import AVFoundation
+import Caching
 import Foundation
 import PlaybackCore
+import PlaylistTesting
 import Testing
 import WidgetKit
-@testable import Caching
 @testable import Playlist
 @testable import AppServices
 
@@ -116,7 +117,7 @@ struct WidgetStateServiceRelevanceTests {
 @MainActor
 private func makeTestPlaylistService() -> PlaylistService {
     PlaylistService(
-        fetcher: StubPlaylistFetcher(),
+        fetcher: MockPlaylistFetcher(),
         interval: 60,
         cacheCoordinator: CacheCoordinator(cache: InMemoryCache())
     )
@@ -143,44 +144,6 @@ final class MockWidgetRelevanceUpdater: WidgetRelevanceUpdating {
     }
 }
 
-private struct StubPlaylistFetcher: PlaylistFetcherProtocol {
-    func fetchPlaylist() async -> Playlist { .empty }
-}
-
-private final class InMemoryCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-
-    func metadata(for key: String) -> CacheMetadata? { metadataStorage[key] }
-    func data(for key: String) -> Data? { dataStorage[key] }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        if let data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-
-    func remove(for key: String) {
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-
-    func totalSize() -> Int64 {
-        dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
 
 @Observable
 @MainActor

--- a/Shared/Artwork/Package.swift
+++ b/Shared/Artwork/Package.swift
@@ -18,7 +18,12 @@ let package = Package(
         ),
         .testTarget(
             name: "ArtworkTests",
-            dependencies: ["Artwork", "Caching", "Playlist"]
+            dependencies: [
+                "Artwork",
+                "Caching",
+                "Playlist",
+                .product(name: "PlaylistTesting", package: "Playlist"),
+            ]
         )
     ]
 )

--- a/Shared/Artwork/Tests/ArtworkTests/ArtworkFetcherTests.swift
+++ b/Shared/Artwork/Tests/ArtworkTests/ArtworkFetcherTests.swift
@@ -10,6 +10,7 @@
 
 import Testing
 import Foundation
+import PlaylistTesting
 @testable import Artwork
 @testable import Playlist
 @testable import Core
@@ -70,35 +71,6 @@ extension CGImage {
     }
 }
 #endif
-
-// MARK: - Playcut Test Stub
-
-extension Playcut {
-    /// Creates a Playcut with sensible defaults for testing.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil,
-        songTitle: String = "Test Song",
-        labelName: String? = nil,
-        artistName: String = "Test Artist",
-        releaseTitle: String? = "Test Album",
-        artworkURL: URL? = nil
-    ) -> Playcut {
-        Playcut(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour,
-            songTitle: songTitle,
-            labelName: labelName,
-            artistName: artistName,
-            releaseTitle: releaseTitle,
-            artworkURL: artworkURL
-        )
-    }
-}
 
 // MARK: - iTunesArtworkService Tests (disabled — service removed)
 

--- a/Shared/Artwork/Tests/ArtworkTests/ArtworkServiceTests.swift
+++ b/Shared/Artwork/Tests/ArtworkTests/ArtworkServiceTests.swift
@@ -11,6 +11,7 @@
 import Testing
 import Foundation
 import ImageIO
+import PlaylistTesting
 @testable import Artwork
 @testable import Playlist
 @testable import Core

--- a/Shared/Caching/Sources/Caching/Cache.swift
+++ b/Shared/Caching/Sources/Caching/Cache.swift
@@ -32,7 +32,7 @@ import Foundation
 ///
 /// - ``DiskCache``: File-based cache using extended attributes for metadata storage
 /// - ``MigratingDiskCache``: Wrapper that migrates data between storage locations
-protocol Cache: Sendable {
+public protocol Cache: Sendable {
     /// Retrieves metadata for a cached entry without loading the data.
     ///
     /// This method reads only the metadata (timestamp and lifespan) for an entry,

--- a/Shared/Caching/Sources/Caching/CacheCoordinator.swift
+++ b/Shared/Caching/Sources/Caching/CacheCoordinator.swift
@@ -95,7 +95,7 @@ public final actor CacheCoordinator {
     /// - Parameters:
     ///   - cache: The underlying cache implementation to use for storage.
     ///   - clock: The clock to use for time-based operations. Defaults to ``SystemClock``.
-    internal init(cache: Cache, clock: Clock = SystemClock()) {
+    public init(cache: Cache, clock: Clock = SystemClock()) {
         self.cache = cache
         self.clock = clock
 

--- a/Shared/Caching/Sources/Caching/InMemoryCache.swift
+++ b/Shared/Caching/Sources/Caching/InMemoryCache.swift
@@ -1,0 +1,87 @@
+//
+//  InMemoryCache.swift
+//  Caching
+//
+//  Thread-safe in-memory Cache implementation for isolated test execution.
+//  Use in tests to avoid file system dependencies and enable parallel test runs.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Thread-safe in-memory implementation of the ``Cache`` protocol for testing.
+///
+/// Use this instead of ``DiskCache`` in tests to avoid file system dependencies
+/// and enable parallel test execution without interference. Each test can create
+/// its own instance, just like ``InMemoryDefaults``.
+///
+/// ## Usage
+///
+/// ```swift
+/// let cache = InMemoryCache()
+/// let coordinator = CacheCoordinator(cache: cache)
+/// ```
+public final class InMemoryCache: Cache, @unchecked Sendable {
+    private var dataStorage: [String: Data] = [:]
+    private var metadataStorage: [String: CacheMetadata] = [:]
+    private let lock = NSLock()
+
+    public init() {}
+
+    public func metadata(for key: String) -> CacheMetadata? {
+        lock.lock()
+        defer { lock.unlock() }
+        return metadataStorage[key]
+    }
+
+    public func data(for key: String) -> Data? {
+        lock.lock()
+        defer { lock.unlock() }
+        return dataStorage[key]
+    }
+
+    public func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let data {
+            dataStorage[key] = data
+            metadataStorage[key] = metadata
+        } else {
+            _remove(for: key)
+        }
+    }
+
+    public func remove(for key: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        _remove(for: key)
+    }
+
+    public func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
+        lock.lock()
+        defer { lock.unlock() }
+        return metadataStorage.map { ($0.key, $0.value) }
+    }
+
+    public func clearAll() {
+        lock.lock()
+        defer { lock.unlock() }
+        dataStorage.removeAll()
+        metadataStorage.removeAll()
+    }
+
+    public func totalSize() -> Int64 {
+        lock.lock()
+        defer { lock.unlock() }
+        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
+    }
+
+    // MARK: - Private
+
+    private func _remove(for key: String) {
+        dataStorage.removeValue(forKey: key)
+        metadataStorage.removeValue(forKey: key)
+    }
+}

--- a/Shared/Caching/Tests/CachingTests/CacheCoordinatorTests.swift
+++ b/Shared/Caching/Tests/CachingTests/CacheCoordinatorTests.swift
@@ -61,62 +61,6 @@ final class MockClock: Clock, @unchecked Sendable {
     }
 }
 
-// MARK: - Mock Cache
-
-final class MockCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-    private let lock = NSLock()
-
-    func metadata(for key: String) -> CacheMetadata? {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage[key]
-    }
-    
-    func data(for key: String) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage[key]
-    }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        if let data = data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-    
-    func remove(for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-
-    func totalSize() -> Int64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
 
 // MARK: - Test Data Types
 
@@ -142,7 +86,7 @@ struct CacheCoordinatorTests {
     @Test("Stores and retrieves string values")
     func storesAndRetrievesStrings() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "test-string"
         let value = "Hello, Cache!"
@@ -158,7 +102,7 @@ struct CacheCoordinatorTests {
     @Test("Stores and retrieves integer values")
     func storesAndRetrievesIntegers() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "test-int"
         let value = 42
@@ -174,7 +118,7 @@ struct CacheCoordinatorTests {
     @Test("Stores and retrieves custom structs")
     func storesAndRetrievesCustomStructs() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "test-person"
         let value = TestPerson(name: "Alice", age: 30)
@@ -190,7 +134,7 @@ struct CacheCoordinatorTests {
     @Test("Stores and retrieves arrays")
     func storesAndRetrievesArrays() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "test-array"
         let value = [1, 2, 3, 4, 5]
@@ -206,7 +150,7 @@ struct CacheCoordinatorTests {
     @Test("Stores and retrieves dictionaries")
     func storesAndRetrievesDictionaries() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "test-dict"
         let value = ["name": "Bob", "city": "NYC"]
@@ -224,7 +168,7 @@ struct CacheCoordinatorTests {
     @Test("Throws error for expired values")
     func throwsErrorForExpiredValues() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let mockClock = MockClock()
         let coordinator = CacheCoordinator(cache: mockCache, clock: mockClock)
         let key = "expired-value"
@@ -245,7 +189,7 @@ struct CacheCoordinatorTests {
     @Test("Non-expired values are accessible")
     func nonExpiredValuesAreAccessible() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let mockClock = MockClock()
         let coordinator = CacheCoordinator(cache: mockCache, clock: mockClock)
         let key = "valid-value"
@@ -265,7 +209,7 @@ struct CacheCoordinatorTests {
     @Test("Expired records are removed from cache")
     func expiredRecordsAreRemoved() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let mockClock = MockClock()
         let coordinator = CacheCoordinator(cache: mockCache, clock: mockClock)
         let key = "to-be-removed"
@@ -294,7 +238,7 @@ struct CacheCoordinatorTests {
     @Test("Throws error for non-existent key")
     func throwsErrorForNonExistentKey() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "does-not-exist"
 
@@ -307,7 +251,7 @@ struct CacheCoordinatorTests {
     @Test("Throws error for type mismatch")
     func throwsErrorForTypeMismatch() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "type-mismatch"
 
@@ -325,7 +269,7 @@ struct CacheCoordinatorTests {
     @Test("Setting nil removes value")
     func settingNilRemovesValue() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "remove-with-nil"
         let value = "To be removed"
@@ -349,7 +293,7 @@ struct CacheCoordinatorTests {
     @Test("Overwrites existing values")
     func overwritesExistingValues() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "overwrite-test"
         let initialValue = "Initial"
@@ -368,7 +312,7 @@ struct CacheCoordinatorTests {
     @Test("Updates lifespan when overwriting")
     func updatesLifespanWhenOverwriting() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let mockClock = MockClock()
         let coordinator = CacheCoordinator(cache: mockCache, clock: mockClock)
         let key = "lifespan-update"
@@ -396,7 +340,7 @@ struct CacheCoordinatorTests {
     @Test("Handles nested structures")
     func handlesNestedStructures() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "nested-test"
         let value = [
@@ -415,7 +359,7 @@ struct CacheCoordinatorTests {
     @Test("Handles optional values")
     func handlesOptionalValues() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "optional-test"
         let value: String? = "Optional value"
@@ -433,7 +377,7 @@ struct CacheCoordinatorTests {
     @Test("Handles concurrent reads and writes")
     func handlesConcurrentReadsAndWrites() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
 
         // When - Concurrent writes
@@ -459,7 +403,7 @@ struct CacheCoordinatorTests {
     @Test("Actor isolation prevents data races")
     func actorIsolationPreventsDataRaces() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "race-test"
 
@@ -503,7 +447,7 @@ struct CacheCoordinatorTests {
     @Test("Handles empty strings")
     func handlesEmptyStrings() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "empty-string"
         let value = ""
@@ -519,7 +463,7 @@ struct CacheCoordinatorTests {
     @Test("Handles zero values")
     func handlesZeroValues() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "zero-value"
         let value = 0
@@ -535,7 +479,7 @@ struct CacheCoordinatorTests {
     @Test("Handles negative lifespan gracefully")
     func handlesNegativeLifespan() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "negative-lifespan"
         let value = "Already expired"
@@ -552,7 +496,7 @@ struct CacheCoordinatorTests {
     @Test("Handles very large lifespan")
     func handlesVeryLargeLifespan() async throws {
         // Given
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "large-lifespan"
         let value = "Long lived"

--- a/Shared/Caching/Tests/CachingTests/DiskCacheReproductionTests.swift
+++ b/Shared/Caching/Tests/CachingTests/DiskCacheReproductionTests.swift
@@ -32,7 +32,7 @@ struct DiskCacheReproductionTests {
     @Test("Corrupted data is evicted on decode failure")
     func corruptedDataIsEvictedOnDecodeFailure() async {
         // Given: A mock cache with corrupted data (valid metadata, invalid JSON payload)
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let key = "corrupted_playlist"
 
         // Write invalid JSON directly to the cache with valid metadata
@@ -61,7 +61,7 @@ struct DiskCacheReproductionTests {
     @Test("Second read after eviction throws noCachedResult instead of decode error")
     func secondReadAfterEvictionThrowsNoCachedResult() async {
         // Given: A mock cache with corrupted data
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let key = "persistent_corruption"
         let corruptedData = "{ invalid json }".data(using: .utf8)!
         let metadata = CacheMetadata(lifespan: 3600)
@@ -88,7 +88,7 @@ struct DiskCacheReproductionTests {
     @Test("purgeExpiredEntries deletes expired entries on coordinator initialization")
     func purgeExpiredEntriesDeletesExpiredEntries() async {
         // Given: A mock cache pre-populated with expired data
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let expiredKey = "expired_on_init"
         let expiredData = "some data".data(using: .utf8)!
         
@@ -113,7 +113,7 @@ struct DiskCacheReproductionTests {
     @Test("purgeExpiredEntries preserves valid entries while deleting expired ones")
     func purgeExpiredEntriesPreservesValidEntries() async throws {
         // Given: A cache with both valid and expired entries
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let validKey = "valid_entry"
         let expiredKey = "expired_entry"
         
@@ -152,7 +152,7 @@ struct DiskCacheReproductionTests {
     @Test("Type mismatch evicts entry since it produces a DecodingError")
     func typeMismatchEvictsEntry() async throws {
         // Given: Store a value as String
-        let mockCache = MockCache()
+        let mockCache = InMemoryCache()
         let coordinator = CacheCoordinator(cache: mockCache)
         let key = "type_mismatch"
 

--- a/Shared/Metadata/Package.swift
+++ b/Shared/Metadata/Package.swift
@@ -19,7 +19,12 @@ let package = Package(
         ),
         .testTarget(
             name: "MetadataTests",
-            dependencies: ["Metadata", "Caching", "Playlist"]
+            dependencies: [
+                "Metadata",
+                "Caching",
+                "Playlist",
+                .product(name: "PlaylistTesting", package: "Playlist"),
+            ]
         )
     ]
 )

--- a/Shared/Metadata/Tests/MetadataTests/PlaycutMetadataServiceCachingTests.swift
+++ b/Shared/Metadata/Tests/MetadataTests/PlaycutMetadataServiceCachingTests.swift
@@ -12,6 +12,7 @@ import Testing
 import Foundation
 import Core
 import Playlist
+import PlaylistTesting
 @testable import Caching
 @testable import Metadata
 
@@ -98,33 +99,6 @@ final class MetadataMockWebSession: WebSession, @unchecked Sendable {
         responses.removeAll()
         requestedURLs.removeAll()
         requestCount = 0
-    }
-}
-
-// MARK: - Playcut Test Stub
-
-extension Playcut {
-    /// Creates a Playcut with sensible defaults for testing.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil,
-        songTitle: String = "Test Song",
-        labelName: String? = nil,
-        artistName: String = "Test Artist",
-        releaseTitle: String? = "Test Album"
-    ) -> Playcut {
-        Playcut(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour,
-            songTitle: songTitle,
-            labelName: labelName,
-            artistName: artistName,
-            releaseTitle: releaseTitle
-        )
     }
 }
 

--- a/Shared/Metadata/Tests/MetadataTests/PlaycutMetadataServiceHTTPTests.swift
+++ b/Shared/Metadata/Tests/MetadataTests/PlaycutMetadataServiceHTTPTests.swift
@@ -12,6 +12,7 @@ import Testing
 import Foundation
 import Core
 import Playlist
+import PlaylistTesting
 @testable import Caching
 @testable import Metadata
 

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/RequestLineAuthFeatureTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/RequestLineAuthFeatureTests.swift
@@ -189,12 +189,3 @@ struct RequestLineAuthFeatureTests {
     }
 }
 
-// MARK: - Mock Feature Flag Provider
-
-final class MockFeatureFlagProvider: FeatureFlagProvider {
-    var flags: [String: Any] = [:]
-
-    func getFeatureFlag(_ key: String) -> Any? {
-        flags[key]
-    }
-}

--- a/Shared/Playlist/Package.swift
+++ b/Shared/Playlist/Package.swift
@@ -4,7 +4,10 @@ import PackageDescription
 let package = Package(
     name: "Playlist",
     platforms: [.iOS("18.4"), .watchOS(.v11), .macOS(.v15)],
-    products: [.library(name: "Playlist", targets: ["Playlist"])],
+    products: [
+        .library(name: "Playlist", targets: ["Playlist"]),
+        .library(name: "PlaylistTesting", targets: ["PlaylistTesting"]),
+    ],
     dependencies: [
         .package(name: "Analytics", path: "../Analytics"),
         .package(name: "Core", path: "../Core"),
@@ -17,10 +20,15 @@ let package = Package(
             dependencies: ["Analytics", "Core", "Caching", "Logger"],
             resources: [.process("Playlist Detail Assets.xcassets")]
         ),
+        .target(
+            name: "PlaylistTesting",
+            dependencies: ["Playlist"]
+        ),
         .testTarget(
             name: "PlaylistTests",
             dependencies: [
                 "Playlist",
+                "PlaylistTesting",
                 "Caching",
                 .product(name: "AnalyticsTesting", package: "Analytics"),
                 .product(name: "LoggerTesting", package: "Logger"),

--- a/Shared/Playlist/Sources/PlaylistTesting/MockPlaylistFetcher.swift
+++ b/Shared/Playlist/Sources/PlaylistTesting/MockPlaylistFetcher.swift
@@ -1,0 +1,67 @@
+//
+//  MockPlaylistFetcher.swift
+//  PlaylistTesting
+//
+//  Test double for PlaylistFetcherProtocol that returns configurable playlists.
+//  Replaces the identical MockPlaylistFetcher classes in PlaylistTests and AppServicesTests.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+@_exported import Playlist
+
+/// Test double for ``PlaylistFetcherProtocol`` that returns a configurable playlist.
+///
+/// ```swift
+/// let fetcher = MockPlaylistFetcher()
+/// fetcher.playlistToReturn = .stub(playcuts: [.stub(songTitle: "la paradoja")])
+/// let playlist = await fetcher.fetchPlaylist()
+/// #expect(fetcher.callCount == 1)
+/// ```
+public final class MockPlaylistFetcher: PlaylistFetcherProtocol, @unchecked Sendable {
+    /// The playlist to return from ``fetchPlaylist()``.
+    public var playlistToReturn: Playlist = .empty
+
+    /// The number of times ``fetchPlaylist()`` has been called.
+    public var callCount = 0
+
+    public init() {}
+
+    public func fetchPlaylist() async -> Playlist {
+        callCount += 1
+        return playlistToReturn
+    }
+}
+
+/// Test double for ``PlaylistDataSource`` that returns a configurable playlist or throws.
+///
+/// ```swift
+/// let dataSource = MockPlaylistDataSource()
+/// dataSource.playlistToReturn = .stub(playcuts: [.stub(songTitle: "VI Scose Poise")])
+/// let playlist = try await dataSource.getPlaylist()
+/// #expect(dataSource.fetchCount == 1)
+/// ```
+public final class MockPlaylistDataSource: PlaylistDataSource, @unchecked Sendable {
+    /// The playlist to return from ``getPlaylist()``.
+    public var playlistToReturn: Playlist = .empty
+
+    /// An error to throw from ``getPlaylist()``, if set.
+    public var errorToThrow: Error?
+
+    /// The number of times ``getPlaylist()`` has been called.
+    public var fetchCount = 0
+
+    public init() {}
+
+    public func getPlaylist() async throws -> Playlist {
+        fetchCount += 1
+
+        if let error = errorToThrow {
+            throw error
+        }
+
+        return playlistToReturn
+    }
+}

--- a/Shared/Playlist/Sources/PlaylistTesting/PlaylistStubs.swift
+++ b/Shared/Playlist/Sources/PlaylistTesting/PlaylistStubs.swift
@@ -1,0 +1,103 @@
+//
+//  PlaylistStubs.swift
+//  PlaylistTesting
+//
+//  Convenience stub factories for Playcut, Playlist, Breakpoint, and Talkset.
+//  Centralizes the test stub extensions that were duplicated across test targets.
+//
+//  Created by Jake Bromberg on 03/29/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Playlist
+
+extension Playcut {
+    /// Creates a Playcut with sensible defaults for testing.
+    ///
+    /// - Parameters:
+    ///   - id: Unique identifier. Defaults to 1.
+    ///   - hour: Hour timestamp in milliseconds since epoch. Defaults to 1000.
+    ///   - chronOrderID: Chronological order ID. Defaults to matching `id`.
+    ///   - timeCreated: Creation timestamp in milliseconds since epoch. Defaults to matching `hour`.
+    ///   - songTitle: Song title. Defaults to "Test Song".
+    ///   - labelName: Record label name. Defaults to nil.
+    ///   - artistName: Artist name. Defaults to "Test Artist".
+    ///   - releaseTitle: Album/release title. Defaults to "Test Album".
+    ///   - rotation: Whether this is a rotation play. Defaults to false.
+    ///   - artworkURL: Optional artwork URL. Defaults to nil.
+    public static func stub(
+        id: UInt64 = 1,
+        hour: UInt64 = 1000,
+        chronOrderID: UInt64? = nil,
+        timeCreated: UInt64? = nil,
+        songTitle: String = "Test Song",
+        labelName: String? = nil,
+        artistName: String = "Test Artist",
+        releaseTitle: String? = "Test Album",
+        rotation: Bool = false,
+        artworkURL: URL? = nil
+    ) -> Playcut {
+        Playcut(
+            id: id,
+            hour: hour,
+            chronOrderID: chronOrderID ?? id,
+            timeCreated: timeCreated ?? hour,
+            songTitle: songTitle,
+            labelName: labelName,
+            artistName: artistName,
+            releaseTitle: releaseTitle,
+            rotation: rotation,
+            artworkURL: artworkURL
+        )
+    }
+}
+
+extension Breakpoint {
+    /// Creates a Breakpoint with sensible defaults for testing.
+    public static func stub(
+        id: UInt64 = 1,
+        hour: UInt64 = 1000,
+        chronOrderID: UInt64? = nil,
+        timeCreated: UInt64? = nil
+    ) -> Breakpoint {
+        Breakpoint(
+            id: id,
+            hour: hour,
+            chronOrderID: chronOrderID ?? id,
+            timeCreated: timeCreated ?? hour
+        )
+    }
+}
+
+extension Talkset {
+    /// Creates a Talkset with sensible defaults for testing.
+    public static func stub(
+        id: UInt64 = 1,
+        hour: UInt64 = 1000,
+        chronOrderID: UInt64? = nil,
+        timeCreated: UInt64? = nil
+    ) -> Talkset {
+        Talkset(
+            id: id,
+            hour: hour,
+            chronOrderID: chronOrderID ?? id,
+            timeCreated: timeCreated ?? hour
+        )
+    }
+}
+
+extension Playlist {
+    /// Creates a Playlist stub for testing.
+    public static func stub(
+        playcuts: [Playcut] = [],
+        breakpoints: [Breakpoint] = [],
+        talksets: [Talkset] = []
+    ) -> Playlist {
+        Playlist(
+            playcuts: playcuts,
+            breakpoints: breakpoints,
+            talksets: talksets
+        )
+    }
+}

--- a/Shared/Playlist/Tests/PlaylistTests/Helpers/Playcut+Stub.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/Helpers/Playcut+Stub.swift
@@ -2,98 +2,11 @@
 //  Playcut+Stub.swift
 //  Playlist
 //
-//  Test helper for creating Playcut instances with sensible defaults.
+//  Re-exports PlaylistTesting stubs for backward compatibility.
+//  The canonical stub implementations live in PlaylistTesting.
 //
-//  Created by Claude on 01/29/26.
+//  Created by Jake Bromberg on 01/29/26.
 //  Copyright © 2026 WXYC. All rights reserved.
 //
 
-import Foundation
-@testable import Playlist
-
-extension Playcut {
-    /// Creates a Playcut with sensible defaults for testing.
-    ///
-    /// - Parameters:
-    ///   - id: Unique identifier. Defaults to 1.
-    ///   - hour: Hour timestamp in milliseconds since epoch. Defaults to 1000.
-    ///   - chronOrderID: Chronological order ID. Defaults to matching `id`.
-    ///   - timeCreated: Creation timestamp in milliseconds since epoch. Defaults to matching `hour`.
-    ///   - songTitle: Song title. Defaults to "Test Song".
-    ///   - labelName: Record label name. Defaults to nil.
-    ///   - artistName: Artist name. Defaults to "Test Artist".
-    ///   - releaseTitle: Album/release title. Defaults to "Test Album".
-    ///   - rotation: Whether this is a rotation play. Defaults to false.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil,
-        songTitle: String = "Test Song",
-        labelName: String? = nil,
-        artistName: String = "Test Artist",
-        releaseTitle: String? = "Test Album",
-        rotation: Bool = false
-    ) -> Playcut {
-        Playcut(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour,
-            songTitle: songTitle,
-            labelName: labelName,
-            artistName: artistName,
-            releaseTitle: releaseTitle,
-            rotation: rotation
-        )
-    }
-}
-
-extension Breakpoint {
-    /// Creates a Breakpoint with sensible defaults for testing.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil
-    ) -> Breakpoint {
-        Breakpoint(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour
-        )
-    }
-}
-
-extension Talkset {
-    /// Creates a Talkset with sensible defaults for testing.
-    static func stub(
-        id: UInt64 = 1,
-        hour: UInt64 = 1000,
-        chronOrderID: UInt64? = nil,
-        timeCreated: UInt64? = nil
-    ) -> Talkset {
-        Talkset(
-            id: id,
-            hour: hour,
-            chronOrderID: chronOrderID ?? id,
-            timeCreated: timeCreated ?? hour
-        )
-    }
-}
-
-extension Playlist {
-    /// Creates an empty Playlist for testing.
-    static func stub(
-        playcuts: [Playcut] = [],
-        breakpoints: [Breakpoint] = [],
-        talksets: [Talkset] = []
-    ) -> Playlist {
-        Playlist(
-            playcuts: playcuts,
-            breakpoints: breakpoints,
-            talksets: talksets
-        )
-    }
-}
+@_exported import PlaylistTesting

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistAPIVersionTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistAPIVersionTests.swift
@@ -11,17 +11,8 @@
 import Testing
 import Foundation
 import Analytics
+import AnalyticsTesting
 @testable import Playlist
-
-// MARK: - Mock Feature Flag Provider
-
-final class MockFeatureFlagProvider: FeatureFlagProvider {
-    var flagValues: [String: Any] = [:]
-
-    func getFeatureFlag(_ key: String) -> Any? {
-        flagValues[key]
-    }
-}
 
 // MARK: - PlaylistAPIVersion Tests
 
@@ -51,7 +42,7 @@ struct PlaylistAPIVersionTests {
     @Test("Returns v2 when feature flag is set to v2")
     func returnsV2WhenFeatureFlagIsV2() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = "v2"
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = "v2"
         let defaults = makeTestDefaults()
 
         let version = PlaylistAPIVersion.loadActive(
@@ -65,7 +56,7 @@ struct PlaylistAPIVersionTests {
     @Test("Returns v1 when feature flag is set to v1")
     func returnsV1WhenFeatureFlagIsV1() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = "v1"
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = "v1"
         let defaults = makeTestDefaults()
 
         let version = PlaylistAPIVersion.loadActive(
@@ -79,7 +70,7 @@ struct PlaylistAPIVersionTests {
     @Test("Manual override takes priority over feature flag")
     func manualOverrideTakesPriority() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = "v1"
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = "v1"
         let defaults = makeTestDefaults()
 
         // Set manual override to v2
@@ -96,7 +87,7 @@ struct PlaylistAPIVersionTests {
     @Test("Clearing override reverts to feature flag")
     func clearingOverrideRevertsToFeatureFlag() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = "v2"
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = "v2"
         let defaults = makeTestDefaults()
 
         // Set manual override to v1
@@ -117,7 +108,7 @@ struct PlaylistAPIVersionTests {
     @Test("Invalid feature flag value falls back to default")
     func invalidFeatureFlagFallsBackToDefault() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = "v3"  // Invalid
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = "v3"  // Invalid
         let defaults = makeTestDefaults()
 
         let version = PlaylistAPIVersion.loadActive(
@@ -131,7 +122,7 @@ struct PlaylistAPIVersionTests {
     @Test("Non-string feature flag value falls back to default")
     func nonStringFeatureFlagFallsBackToDefault() {
         let mockProvider = MockFeatureFlagProvider()
-        mockProvider.flagValues[PlaylistAPIVersion.featureFlagKey] = true  // Boolean, not string
+        mockProvider.flags[PlaylistAPIVersion.featureFlagKey] = true  // Boolean, not string
         let defaults = makeTestDefaults()
 
         let version = PlaylistAPIVersion.loadActive(

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistFetcherTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistFetcherTests.swift
@@ -14,6 +14,7 @@ import Analytics
 import AnalyticsTesting
 import Logger
 import LoggerTesting
+import PlaylistTesting
 @testable import Playlist
 
 // MARK: - PlaylistFetcher Tests
@@ -171,20 +172,3 @@ struct DataMojibakeRepairTests {
     }
 }
 
-// MARK: - Test Doubles
-
-final class MockPlaylistDataSource: PlaylistDataSource, @unchecked Sendable {
-    var playlistToReturn: Playlist = .empty
-    var errorToThrow: Error?
-    var fetchCount = 0
-
-    func getPlaylist() async throws -> Playlist {
-        fetchCount += 1
-
-        if let error = errorToThrow {
-            throw error
-        }
-
-        return playlistToReturn
-    }
-}

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceBackgroundRefreshTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceBackgroundRefreshTests.swift
@@ -12,10 +12,9 @@
 
 import Testing
 import Foundation
+import PlaylistTesting
 @testable import Playlist
 @testable import Caching
-
-// PlaylistServiceMockCache is defined in PlaylistServiceCachingTests.swift
 
 @Suite("PlaylistService Background Refresh Tests")
 struct PlaylistServiceBackgroundRefreshTests {
@@ -23,7 +22,7 @@ struct PlaylistServiceBackgroundRefreshTests {
     @Test("fetchAndCachePlaylist invalidates existing cache")
     func fetchAndCachePlaylistInvalidatesExistingCache() async throws {
         // Given - Service with cached data
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let oldPlaylist = Playlist.stub(playcuts: [
             .stub(songTitle: "Old Song", artistName: "Old Artist", releaseTitle: nil)
@@ -60,7 +59,7 @@ struct PlaylistServiceBackgroundRefreshTests {
     @Test("fetchAndCachePlaylist always calls fetcher even with valid cache")
     func fetchAndCachePlaylistAlwaysCallsFetcher() async throws {
         // Given - Valid cached data
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let cachedPlaylist = Playlist.stub(playcuts: [
             .stub(songTitle: "Cached", artistName: "Artist", releaseTitle: nil)

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceCachingTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceCachingTests.swift
@@ -14,67 +14,9 @@
 
 import Testing
 import Foundation
+import PlaylistTesting
 @testable import Playlist
 @testable import Caching
-
-// MARK: - Test Mock Cache
-
-/// Mock cache for PlaylistService caching tests
-/// (Defined locally to avoid ambiguity with other MockCache classes)
-final class PlaylistServiceMockCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-    private let lock = NSLock()
-    
-    func metadata(for key: String) -> CacheMetadata? {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage[key]
-    }
-
-    func data(for key: String) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage[key]
-    }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        if let data = data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-    
-    func remove(for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-
-    func totalSize() -> Int64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
 
 // MARK: - Tests
 
@@ -86,7 +28,7 @@ struct PlaylistServiceCachingTests {
     @Test("Loads cached playlist on initialization if available", .timeLimit(.minutes(1)))
     func loadsCachedPlaylistOnInit() async throws {
         // Given - Set up cache with a playlist
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let cachedPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Cached Song", artistName: "Cached Artist")])
 
@@ -119,7 +61,7 @@ struct PlaylistServiceCachingTests {
     @Test("Does not load expired cached playlist", .timeLimit(.minutes(1)))
     func doesNotLoadExpiredCache() async throws {
         // Given - Set up cache with expired playlist
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let expiredPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Expired Song", artistName: "Expired Artist")])
 
@@ -160,7 +102,7 @@ struct PlaylistServiceCachingTests {
     @Test("fetchAndCachePlaylist always fetches fresh data")
     func fetchAndCachePlaylistAlwaysFetchesFresh() async throws {
         // Given - Set up service with cached data
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let cachedPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Cached Song", artistName: "Cached Artist")])
 
@@ -196,7 +138,7 @@ struct PlaylistServiceCachingTests {
     @Test("fetchAndCachePlaylist updates cache even if playlist unchanged")
     func fetchAndCachePlaylistUpdatesCacheEvenIfUnchanged() async throws {
         // Given
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let mockFetcher = MockPlaylistFetcher()
         mockFetcher.playlistToReturn = .stub(playcuts: [.stub(songTitle: "Same Song", artistName: "Same Artist")])
@@ -220,7 +162,7 @@ struct PlaylistServiceCachingTests {
     @Test("Regular fetching caches results", .timeLimit(.minutes(1)))
     func regularFetchingCachesResults() async throws {
         // Given
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let mockFetcher = MockPlaylistFetcher()
         mockFetcher.playlistToReturn = .stub(playcuts: [.stub(songTitle: "Fetched Song", artistName: "Fetched Artist")])
@@ -248,7 +190,7 @@ struct PlaylistServiceCachingTests {
     @Test("Cache expires after 15 minutes")
     func cacheExpiresAfter15Minutes() async throws {
         // Given - Create a playlist cached 16 minutes ago
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let oldPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Old Song", artistName: "Old Artist")])
         
@@ -271,7 +213,7 @@ struct PlaylistServiceCachingTests {
     @Test("Cache is valid within 15 minutes")
     func cacheIsValidWithin15Minutes() async throws {
         // Given - Create a playlist cached 10 minutes ago
-        let mockCache = PlaylistServiceMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let recentPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Recent Song", artistName: "Recent Artist")])
 

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceRaceConditionTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceRaceConditionTests.swift
@@ -10,66 +10,9 @@
 
 import Testing
 import Foundation
+import PlaylistTesting
 @testable import Playlist
 @testable import Caching
-
-// MARK: - Mock Cache for Tests
-
-/// In-memory cache for isolated test execution (race condition tests)
-final class RaceConditionTestMockCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-    private let lock = NSLock()
-
-    func metadata(for key: String) -> CacheMetadata? {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage[key]
-    }
-    
-    func data(for key: String) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage[key]
-    }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        if let data = data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-    
-    func remove(for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-    
-    func totalSize() -> Int64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
 
 /// Mock fetcher for tracking concurrency in race condition tests
 actor ConcurrentTrackingMockFetcher: PlaylistFetcherProtocol {
@@ -114,7 +57,7 @@ struct PlaylistServiceRaceConditionTests {
         let service = PlaylistService(
             fetcher: tracker,
             interval: 1.0, // Short interval for testing
-            cacheCoordinator: CacheCoordinator(cache: RaceConditionTestMockCache())
+            cacheCoordinator: CacheCoordinator(cache: InMemoryCache())
         )
 
         // When: Many observers subscribe concurrently and consume values
@@ -161,7 +104,7 @@ struct PlaylistServiceRaceConditionTests {
         let service = PlaylistService(
             fetcher: tracker,
             interval: 0.2, // Short interval to make test faster
-            cacheCoordinator: CacheCoordinator(cache: RaceConditionTestMockCache())
+            cacheCoordinator: CacheCoordinator(cache: InMemoryCache())
         )
 
         // Create some observers that consume a value then disconnect
@@ -205,7 +148,7 @@ struct PlaylistServiceRaceConditionTests {
         let service = PlaylistService(
             fetcher: tracker,
             interval: 1.0,
-            cacheCoordinator: CacheCoordinator(cache: RaceConditionTestMockCache())
+            cacheCoordinator: CacheCoordinator(cache: InMemoryCache())
         )
         
         // Use a Task to properly manage the stream lifecycle

--- a/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/PlaylistServiceTests.swift
@@ -10,82 +10,15 @@
 
 import Testing
 import Foundation
+import PlaylistTesting
 @testable import Playlist
 @testable import Caching
 
-// MARK: - Mock PlaylistFetcher
+// MARK: - Helpers
 
-final class MockPlaylistFetcher: PlaylistFetcherProtocol, @unchecked Sendable {
-    var playlistToReturn: Playlist = .empty
-    var callCount = 0
-
-    func fetchPlaylist() async -> Playlist {
-        callCount += 1
-        return playlistToReturn
-    }
-}
-
-// MARK: - Mock Cache for Tests
-
-/// In-memory cache for isolated test execution
-final class PlaylistTestMockCache: Cache, @unchecked Sendable {
-    private var dataStorage: [String: Data] = [:]
-    private var metadataStorage: [String: CacheMetadata] = [:]
-    private let lock = NSLock()
-
-    func metadata(for key: String) -> CacheMetadata? {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage[key]
-    }
-    
-    func data(for key: String) -> Data? {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage[key]
-    }
-
-    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        if let data = data {
-            dataStorage[key] = data
-            metadataStorage[key] = metadata
-        } else {
-            remove(for: key)
-        }
-    }
-    
-    func remove(for key: String) {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeValue(forKey: key)
-        metadataStorage.removeValue(forKey: key)
-    }
-
-    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
-        lock.lock()
-        defer { lock.unlock() }
-        return metadataStorage.map { ($0.key, $0.value) }
-    }
-
-    func clearAll() {
-        lock.lock()
-        defer { lock.unlock() }
-        dataStorage.removeAll()
-        metadataStorage.removeAll()
-    }
-
-    func totalSize() -> Int64 {
-        lock.lock()
-        defer { lock.unlock() }
-        return dataStorage.values.reduce(0) { $0 + Int64($1.count) }
-    }
-}
-
-/// Helper to create an isolated cache coordinator for testing
+/// Helper to create an isolated cache coordinator for testing.
 func makeTestCacheCoordinator() -> CacheCoordinator {
-    CacheCoordinator(cache: PlaylistTestMockCache())
+    CacheCoordinator(cache: InMemoryCache())
 }
 
 // MARK: - Tests
@@ -384,7 +317,7 @@ struct PlaylistServiceTests {
     @Test("Observer receives cached data even if subscription happens during cache load", .timeLimit(.minutes(1)))
     func observerReceivesCachedDataDuringCacheLoad() async throws {
         // Given - Pre-populate cache before creating service
-        let mockCache = PlaylistTestMockCache()
+        let mockCache = InMemoryCache()
         let cacheCoordinator = CacheCoordinator(cache: mockCache)
         let cachedPlaylist = Playlist.stub(playcuts: [.stub(songTitle: "Pre-cached Song", artistName: "Pre-cached Artist")])
 


### PR DESCRIPTION
## Summary
- Add `InMemoryCache` in Caching for test isolation (replaces per-test DiskCache setup)
- Add `PlaylistTesting` library with `MockPlaylistFetcher` and `PlaylistStubs`
- Add `MockFeatureFlagProvider` to `AnalyticsTesting`
- Refactor 22 test files across 6 packages to use shared utilities
- Net -247 lines (385 added, 632 removed)

Closes #195