### PR TITLE
Adaptive NavigationSplitView layout for iPad and Mac

### DIFF
--- a/WXYC.xcodeproj/project.pbxproj
+++ b/WXYC.xcodeproj/project.pbxproj
@@ -9,6 +9,8 @@
 /* Begin PBXBuildFile section */
 		062417DC96252E36AE65C585 /* Playback in Frameworks */ = {isa = PBXBuildFile; productRef = E150313F784CF272A32EA642 /* Playback */; };
 		0EEAC96AF698AC55DD08EB7C /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 79AE74A2A92779E80E688376 /* Core */; };
+		0FD4D9EC4F5A4F3AACF0396B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8A3693E141EF47CABE91D00F /* Sentry */; };
+		1529CE89784D4CABA78CA19E /* AppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7FBFF8641D4F629866EB1F /* AppServices */; };
 		160F5276C232F51B9ABD41FA /* Caching in Frameworks */ = {isa = PBXBuildFile; productRef = 8FCE16D2F8F98E766EFCFFDF /* Caching */; };
 		1F3D795595990939AC76274D /* Playlist in Frameworks */ = {isa = PBXBuildFile; productRef = D1362165656CBF5DDD9E5DDA /* Playlist */; };
 		1F511646EB98B7621319A1DA /* AppServices in Frameworks */ = {isa = PBXBuildFile; productRef = EE16E35E8F1311399E5AD843 /* AppServices */; };
@@ -30,32 +32,28 @@
 		23E3942E2F0C85ED009D24CB /* AppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 23TV00032EFC676F0058AD01 /* AppServices */; };
 		23E3942F2F0C85ED009D24CB /* Artwork in Frameworks */ = {isa = PBXBuildFile; productRef = 23TV00042EFC6780ARTWORK01 /* Artwork */; };
 		23E394302F0C85ED009D24CB /* Wallpaper in Frameworks */ = {isa = PBXBuildFile; productRef = 23TV00052EF2C80000WALLPA /* Wallpaper */; };
-
 		2AD59B02211E454634324EEB /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 47B1D80EB160884F8DC37B6A /* Logger */; };
 		2C25163B4CC5F775E9F8409E /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = 33A31E91AA56954894130F50 /* Logger */; };
 		37327445A68BBA56C392BEF7 /* WXUI in Frameworks */ = {isa = PBXBuildFile; productRef = 01163D6D065337EB60F79C5B /* WXUI */; };
 		3FE7F1333D67FB073FBB13EF /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 01BA6F026317213ACE8EE228 /* PostHog */; };
 		524AA009A7901EA1DDC81851 /* PlayerHeaderView in Frameworks */ = {isa = PBXBuildFile; productRef = 35DC07836DEEE44F7B819265 /* PlayerHeaderView */; };
 		62C0D7BB9157E5D3D858DA97 /* Metadata in Frameworks */ = {isa = PBXBuildFile; productRef = BE7D47372C4F1F83B0F271DE /* Metadata */; };
+		7127691612A44A229E553EDE /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 16E246AEBDDC40D3B97316A6 /* Sentry */; };
 		7795E1821F6367CC00C37ED0 /* Playlist in Frameworks */ = {isa = PBXBuildFile; productRef = 0852AD2E14147E5B270AD1F1 /* Playlist */; };
 		78F01F75D235BCEE06C05F71 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = 9AA59EC6C2A143F5728D04F9 /* Analytics */; };
 		7FD230E5DD398FE4B7F0AE06 /* PartyHorn in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF76684E122C2FAD4F26E27 /* PartyHorn */; };
 		9CE357BF402D2D35325581C3 /* MusicShareKit in Frameworks */ = {isa = PBXBuildFile; productRef = 4E0E4513BB04D21BB582E4B0 /* MusicShareKit */; };
 		A17CCEC28257E400D4B99AFF /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 8ED7023BC91B73A942BF53C7 /* Core */; };
 		A2726CC83A5E3D5A0F69D553 /* Core in Frameworks */ = {isa = PBXBuildFile; productRef = 3CABF5AF82DAA2E0D9877A07 /* Core */; };
-		A5D120B4FBE72D5CA761A231 /* WatchXYC.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = E790F2E8AAE12A20CB303818 /* WatchXYC.app */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		A5D120B4FBE72D5CA761A231 /* WatchXYC.app in Embed Watch Content */ = {isa = PBXBuildFile; fileRef = E790F2E8AAE12A20CB303818 /* WatchXYC.app */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		A7CF425E5F8EBCE498636FAB /* Artwork in Frameworks */ = {isa = PBXBuildFile; productRef = 196F9D43ACA1827478F32D5D /* Artwork */; };
 		ADF9E4264AD37AE291C15EF5 /* MusicShareKit in Frameworks */ = {isa = PBXBuildFile; productRef = B1E128B6E39E90EA57C68C69 /* MusicShareKit */; };
 		B0A59156E0821D59D5F50AAE /* Artwork in Frameworks */ = {isa = PBXBuildFile; productRef = 3776C2184A667CCB7B4E0B67 /* Artwork */; };
 		B3C1123B54E860DEF19F22BF /* AppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 932CA5D4CF336582845E6C75 /* AppServices */; };
-		1529CE89784D4CABA78CA19E /* AppServices in Frameworks */ = {isa = PBXBuildFile; productRef = 4F7FBFF8641D4F629866EB1F /* AppServices */; };
 		C13E02E83FC278A2247E0FAC /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 51D35AECC049A83AE7575477 /* PostHog */; };
-		7127691612A44A229E553EDE /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 16E246AEBDDC40D3B97316A6 /* Sentry */; };
-		0FD4D9EC4F5A4F3AACF0396B /* Sentry in Frameworks */ = {isa = PBXBuildFile; productRef = 8A3693E141EF47CABE91D00F /* Sentry */; };
-		DBB13191767501A2D580FD30 /* Request Share Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0C1F6BD9A7F7287CD5CF91CF /* Request Share Extension.appex */; platformFilters = (ios, ); settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		DBB13191767501A2D580FD30 /* Request Share Extension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 0C1F6BD9A7F7287CD5CF91CF /* Request Share Extension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DCF27381E7D5EC54633BE58E /* Logger in Frameworks */ = {isa = PBXBuildFile; productRef = B5DEC242C4D59E9B40D0E365 /* Logger */; };
 		PLAYBACKWATCHOSBUILD0001 /* PlaybackWatchOS in Frameworks */ = {isa = PBXBuildFile; productRef = PLAYBACKWATCHOSDEP00001 /* PlaybackWatchOS */; };
-
 		WXYCINTENTS00000001 /* WXYCIntents in Frameworks */ = {isa = PBXBuildFile; productRef = WXYCINTENTS00000005 /* WXYCIntents */; };
 		WXYCINTENTS00000002 /* WXYCIntents in Frameworks */ = {isa = PBXBuildFile; productRef = WXYCINTENTS00000006 /* WXYCIntents */; };
 /* End PBXBuildFile section */
@@ -154,7 +152,6 @@
 		F77598F39CF7FC65590EA6AF /* AppServices */ = {isa = PBXFileReference; lastKnownFileType = folder; name = AppServices; path = Shared/AppServices; sourceTree = SOURCE_ROOT; };
 		FF0D2C45269DEE0E530C46D3 /* PartyHorn */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PartyHorn; path = Shared/PartyHorn; sourceTree = SOURCE_ROOT; };
 		INTENTSPKGFILEREF000001 /* Intents */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Intents; path = Shared/Intents; sourceTree = SOURCE_ROOT; };
-
 		WALLPAPER0FILEREF0000001 /* Wallpaper */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Wallpaper; path = Shared/Wallpaper; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
 
@@ -181,6 +178,7 @@
 		23A10B242EF5F165001EF136 /* Exceptions for "WXYC" folder in "WXYCTests" target */ = {
 			isa = PBXFileSystemSynchronizedBuildFileExceptionSet;
 			membershipExceptions = (
+				iOS/Tests/WXYCTests/AdaptiveLayoutTests.swift,
 				iOS/Tests/WXYCTests/DiscogsFormatterTests.swift,
 				iOS/Tests/WXYCTests/LinkButtonLabelTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingInfoCenterManagerTests.swift,
@@ -232,6 +230,7 @@
 				"iOS/Request Share Extension/Info.plist",
 				"iOS/Request Share Extension/ShareViewController.swift",
 				iOS/Tests/WXYC.xctestplan,
+				iOS/Tests/WXYCTests/AdaptiveLayoutTests.swift,
 				iOS/Tests/WXYCTests/DiscogsFormatterTests.swift,
 				iOS/Tests/WXYCTests/LinkButtonLabelTests.swift,
 				iOS/Tests/WXYCTests/NowPlayingInfoCenterManagerTests.swift,
@@ -311,7 +310,6 @@
 				236B52062EFC67750058AD01 /* AppServices in Frameworks */,
 				236B51FA2EFC674F0058AD01 /* Caching in Frameworks */,
 				236B52072EFC67800058AD01 /* Playback in Frameworks */,
-
 				236B51D22EFC651A0058AD01 /* SwiftUI.framework in Frameworks */,
 				236B52022EFC67630058AD01 /* Analytics in Frameworks */,
 				236B51D02EFC651A0058AD01 /* WidgetKit.framework in Frameworks */,
@@ -329,7 +327,6 @@
 				9CE357BF402D2D35325581C3 /* MusicShareKit in Frameworks */,
 				062417DC96252E36AE65C585 /* Playback in Frameworks */,
 				160F5276C232F51B9ABD41FA /* Caching in Frameworks */,
-
 				1F3D795595990939AC76274D /* Playlist in Frameworks */,
 				23D418182EF2C80000WALLPA /* Wallpaper in Frameworks */,
 				23D418192EF2C8000DBGPNL /* DebugPanel in Frameworks */,
@@ -355,7 +352,6 @@
 		64915BA4D2117A923D5E4476 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			files = (
-
 				0EEAC96AF698AC55DD08EB7C /* Core in Frameworks */,
 				2AD59B02211E454634324EEB /* Logger in Frameworks */,
 				PLAYBACKWATCHOSBUILD0001 /* PlaybackWatchOS in Frameworks */,
@@ -385,7 +381,6 @@
 		23FB21C52EEA866C0064E6FD /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
-
 				236B51CF2EFC651A0058AD01 /* WidgetKit.framework */,
 				236B51D12EFC651A0058AD01 /* SwiftUI.framework */,
 			);
@@ -447,7 +442,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 236B51DE2EFC651C0058AD01 /* Build configuration list for PBXNativeTarget "NowPlayingWidget" */;
 			buildPhases = (
-
 				236B51CA2EFC651A0058AD01 /* Sources */,
 				236B51CB2EFC651A0058AD01 /* Frameworks */,
 				236B51CC2EFC651A0058AD01 /* Resources */,
@@ -477,7 +471,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = F07B8EB63012AED1DBF55448 /* Build configuration list for PBXNativeTarget "Request Share Extension" */;
 			buildPhases = (
-
 				121F040A2043328980F3406A /* Sources */,
 				B60696590E1538E245DAA075 /* Resources */,
 				5282D69CBC6C3EAF27DE8CBE /* Frameworks */,
@@ -513,7 +506,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 0CF3A4E4F58365C88AF3BEC0 /* Build configuration list for PBXNativeTarget "WatchXYC" */;
 			buildPhases = (
-
 				12A0D2636F71F6DF9021FE60 /* Sources */,
 				64915BA4D2117A923D5E4476 /* Frameworks */,
 				23FB21BC2EEA85BD0064E6FD /* Resources */,
@@ -590,7 +582,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = BCDB07AF50A606A90AFC77E6 /* Build configuration list for PBXNativeTarget "WXYC" */;
 			buildPhases = (
-
 				6AF4C1FE1EAD852AFDE5A6DC /* Sources */,
 				2994456FF2469AAFA85A0645 /* Frameworks */,
 				3FA193A59B6488FC4364B0FD /* Embed Foundation Extensions */,
@@ -696,7 +687,6 @@
 				23D418162EF2C80000WALLPA /* XCLocalSwiftPackageReference "Shared/Wallpaper" */,
 				23B42F952F0209CB007351F1 /* XCLocalSwiftPackageReference "Shared/ColorPalette" */,
 				WXYCINTENTS00000004 /* XCLocalSwiftPackageReference "Shared/Intents" */,
-				F4ADF988FEFD40379D32876C /* XCRemoteSwiftPackageReference "sentry-cocoa" */,
 			);
 			preferredProjectObjectVersion = 90;
 			productRefGroup = 6393B8DD84BA2FE9EA639E2D /* Products */;
@@ -745,18 +735,24 @@
 /* Begin PBXShellScriptBuildPhase section */
 		EE041E6CCD134EE28A57C03B /* Upload Debug Symbols to Sentry */ = {
 			isa = PBXShellScriptBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-			);
 			inputPaths = (
 				"${DWARF_DSYM_FOLDER_PATH}/${DWARF_DSYM_FILE_NAME}/Contents/Resources/DWARF/${TARGET_NAME}",
 			);
 			name = "Upload Debug Symbols to Sentry";
-			outputPaths = (
-			);
-			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
-			shellScript = "if which sentry-cli >/dev/null; then\n  export SENTRY_ORG=wxyc\n  export SENTRY_PROJECT=ios\n  ERROR=$(sentry-cli debug-files upload --include-sources \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 >/dev/null)\n  if [ ! $? -eq 0 ]; then\n    echo \"warning: sentry-cli - $ERROR\"\n  fi\nelse\n  echo \"warning: sentry-cli not installed, skipping debug symbol upload\"\nfi\n";
+			shellScript = (
+				"if which sentry-cli >/dev/null; then",
+				"  export SENTRY_ORG=wxyc",
+				"  export SENTRY_PROJECT=ios",
+				"  ERROR=$(sentry-cli debug-files upload --include-sources \"$DWARF_DSYM_FOLDER_PATH\" 2>&1 >/dev/null)",
+				"  if [ ! $? -eq 0 ]; then",
+				"    echo \"warning: sentry-cli - $ERROR\"",
+				"  fi",
+				"else",
+				"  echo \"warning: sentry-cli not installed, skipping debug symbol upload\"",
+				"fi",
+				"",
+			);
 		};
 /* End PBXShellScriptBuildPhase section */
 
@@ -2482,6 +2478,11 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = Playlist;
 		};
+		16E246AEBDDC40D3B97316A6 /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5A5E08DB4AD4795BBF7F459 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
+		};
 		196F9D43ACA1827478F32D5D /* Artwork */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Artwork;
@@ -2615,6 +2616,10 @@
 			isa = XCSwiftPackageProductDependency;
 			productName = MusicShareKit;
 		};
+		4F7FBFF8641D4F629866EB1F /* AppServices */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = AppServices;
+		};
 		51D35AECC049A83AE7575477 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 999EC3ABE5481213568F4E18 /* XCRemoteSwiftPackageReference "posthog-ios" */;
@@ -2623,6 +2628,11 @@
 		79AE74A2A92779E80E688376 /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Core;
+		};
+		8A3693E141EF47CABE91D00F /* Sentry */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = E5A5E08DB4AD4795BBF7F459 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
+			productName = Sentry;
 		};
 		8ED7023BC91B73A942BF53C7 /* Core */ = {
 			isa = XCSwiftPackageProductDependency;
@@ -2659,7 +2669,6 @@
 		};
 		CA0F906956044B14B8D02D31 /* Sentry */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = F4ADF988FEFD40379D32876C /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
 			productName = Sentry;
 		};
 		D1362165656CBF5DDD9E5DDA /* Playlist */ = {
@@ -2671,10 +2680,6 @@
 			productName = Playback;
 		};
 		EE16E35E8F1311399E5AD843 /* AppServices */ = {
-			isa = XCSwiftPackageProductDependency;
-			productName = AppServices;
-		};
-		4F7FBFF8641D4F629866EB1F /* AppServices */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = AppServices;
 		};
@@ -2691,16 +2696,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = WXYCINTENTS00000004 /* XCLocalSwiftPackageReference "Shared/Intents" */;
 			productName = WXYCIntents;
-		};
-		16E246AEBDDC40D3B97316A6 /* Sentry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E5A5E08DB4AD4795BBF7F459 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
-		};
-		8A3693E141EF47CABE91D00F /* Sentry */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = E5A5E08DB4AD4795BBF7F459 /* XCRemoteSwiftPackageReference "sentry-cocoa" */;
-			productName = Sentry;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/WXYC/iOS/Tests/WXYCTests/AdaptiveLayoutTests.swift
+++ b/WXYC/iOS/Tests/WXYCTests/AdaptiveLayoutTests.swift
@@ -1,0 +1,102 @@
+//
+//  AdaptiveLayoutTests.swift
+//  WXYC
+//
+//  Tests for the selection logic used by RegularLayoutView to derive the selected
+//  playcut from playlist entries and a selection ID binding.
+//
+//  Created by Jake Bromberg on 04/09/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+@testable import WXYC
+@testable import Playlist
+
+@Suite("RegularLayoutView Selection Logic")
+struct AdaptiveLayoutTests {
+
+    @Test("findPlaycut returns matching playcut for valid ID")
+    func findPlaycutWithValidID() {
+        let playcut = Playcut(
+            id: 42,
+            hour: 1000,
+            chronOrderID: 42,
+            timeCreated: 1000,
+            songTitle: "VI Scose Poise",
+            labelName: "Warp",
+            artistName: "Autechre",
+            releaseTitle: "Confield"
+        )
+        let entries: [any PlaylistEntry] = [
+            Breakpoint(id: 1, hour: 900, chronOrderID: 1, timeCreated: 900),
+            playcut,
+            Playcut(id: 99, hour: 1100, chronOrderID: 99, timeCreated: 1100, songTitle: "Moon Pix", labelName: "Matador Records", artistName: "Cat Power", releaseTitle: "Moon Pix"),
+        ]
+
+        let result = RegularLayoutView.findPlaycut(id: 42, in: entries)
+
+        #expect(result == playcut)
+    }
+
+    @Test("findPlaycut returns nil for nil ID")
+    func findPlaycutWithNilID() {
+        let entries: [any PlaylistEntry] = [
+            Playcut(id: 1, hour: 1000, chronOrderID: 1, timeCreated: 1000, songTitle: "la paradoja", labelName: "Sonamos", artistName: "Juana Molina", releaseTitle: "DOGA"),
+        ]
+
+        let result = RegularLayoutView.findPlaycut(id: nil, in: entries)
+
+        #expect(result == nil)
+    }
+
+    @Test("findPlaycut returns nil when ID matches no playcut")
+    func findPlaycutWithNonexistentID() {
+        let entries: [any PlaylistEntry] = [
+            Playcut(id: 1, hour: 1000, chronOrderID: 1, timeCreated: 1000, songTitle: "Back, Baby", labelName: "Drag City", artistName: "Jessica Pratt", releaseTitle: "On Your Own Love Again"),
+            Breakpoint(id: 2, hour: 1100, chronOrderID: 2, timeCreated: 1100),
+        ]
+
+        let result = RegularLayoutView.findPlaycut(id: 999, in: entries)
+
+        #expect(result == nil)
+    }
+
+    @Test("findPlaycut ignores non-Playcut entries with same ID")
+    func findPlaycutIgnoresNonPlaycutEntries() {
+        let entries: [any PlaylistEntry] = [
+            Breakpoint(id: 42, hour: 1000, chronOrderID: 42, timeCreated: 1000),
+            Talkset(id: 42, hour: 1000, chronOrderID: 42, timeCreated: 1000),
+        ]
+
+        let result = RegularLayoutView.findPlaycut(id: 42, in: entries)
+
+        #expect(result == nil)
+    }
+
+    @Test("findPlaycut returns nil for removed playcut, enabling stale selection clearing")
+    func staleSelectionClearing() {
+        let entries: [any PlaylistEntry] = [
+            Playcut(id: 1, hour: 1000, chronOrderID: 1, timeCreated: 1000, songTitle: "Call Your Name", artistName: "Chuquimamani-Condori"),
+            Playcut(id: 2, hour: 1100, chronOrderID: 2, timeCreated: 1100, songTitle: "Gasoline", labelName: "4AD", artistName: "Buck Meek", releaseTitle: "Gasoline"),
+        ]
+
+        // Selected playcut ID 99 was in a previous playlist but not this one
+        let shouldClear = RegularLayoutView.findPlaycut(id: 99, in: entries) == nil
+
+        #expect(shouldClear)
+    }
+
+    @Test("findPlaycut still finds playcut that remains after refresh")
+    func selectionSurvivesRefresh() {
+        let entries: [any PlaylistEntry] = [
+            Playcut(id: 1, hour: 1000, chronOrderID: 1, timeCreated: 1000, songTitle: "Chateau Lobby #4", labelName: "Sub Pop", artistName: "Father John Misty", releaseTitle: "I Love You, Honeybear"),
+            Playcut(id: 2, hour: 1100, chronOrderID: 2, timeCreated: 1100, songTitle: "Stay Chisel", labelName: "Matador Records", artistName: "Large Professor", releaseTitle: "1st Class"),
+        ]
+
+        let result = RegularLayoutView.findPlaycut(id: 1, in: entries)
+
+        #expect(result != nil)
+        #expect(result?.artistName == "Father John Misty")
+    }
+}

--- a/WXYC/iOS/Views/Info Detail/SidebarInfoSection.swift
+++ b/WXYC/iOS/Views/Info Detail/SidebarInfoSection.swift
@@ -1,0 +1,88 @@
+//
+//  SidebarInfoSection.swift
+//  WXYC
+//
+//  Compact info and action section for the NavigationSplitView sidebar. Provides
+//  feedback, request, dial, and merch actions as list rows instead of full-page buttons.
+//
+//  Created by Jake Bromberg on 04/09/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Analytics
+import Core
+import Logger
+import MessageUI
+import MusicShareKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct SidebarInfoSection: View {
+    @State private var showingLogPrompt = false
+    @State private var showingRequestAlert = false
+    @State private var showingMailComposer = false
+    @State private var attachLogsToEmail = false
+    @State private var requestText = ""
+
+    var body: some View {
+        Section {
+            Button("Send feedback", systemImage: "envelope.fill") {
+                showingLogPrompt = true
+            }
+
+            Button("Make a request", systemImage: "message.fill") {
+                showingRequestAlert = true
+            }
+
+            Button("Dial a DJ", systemImage: "phone.fill") {
+                UIApplication.shared.open(RadioStation.WXYC.requestLine)
+            }
+
+            Button("Buy merch", systemImage: "tshirt.fill") {
+                UIApplication.shared.open(RadioStation.WXYC.merchURL)
+            }
+        } header: {
+            Text(RadioStation.WXYC.name)
+        }
+        .alert("Is this a bug?", isPresented: $showingLogPrompt) {
+            Button("Yes!") {
+                attachLogsToEmail = true
+                showingMailComposer = true
+            }
+            Button("S'all good") {
+                attachLogsToEmail = false
+                showingMailComposer = true
+            }
+        } message: {
+            Text("If you're sending feedback because you spotted a bug, would you mind if we attached some debug logs? This will help us figure out what's going wrong and doesn't include any personal info.")
+        }
+        .alert("What would you like to request?", isPresented: $showingRequestAlert) {
+            TextField("Song title and artist", text: $requestText)
+                .autocorrectionDisabled(true)
+
+            Button("Request") {
+                Task {
+                    await sendRequest(message: requestText)
+                    requestText = ""
+                }
+            }
+
+            Button("Cancel", role: .cancel) {
+                requestText = ""
+            }
+        } message: {
+            Text("Please include song title and artist.")
+        }
+        .sheet(isPresented: $showingMailComposer) {
+            MailComposerView(attachLogs: attachLogsToEmail)
+        }
+    }
+
+    private func sendRequest(message: String) async {
+        do {
+            try await RequestService.shared.sendRequest(message: message)
+        } catch {
+            ErrorReporting.shared.report(error, context: "SidebarInfoSection", category: .ui)
+        }
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
@@ -9,6 +9,7 @@
 import Analytics
 import AppIntents
 import AppServices
+import Artwork
 import Metadata
 import MusicShareKit
 import Playlist
@@ -35,6 +36,7 @@ struct PlaycutDetailView: View {
     
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.reviewRequestService) var reviewRequestService
+    @Environment(\.artworkService) private var artworkService
 
     private let metadataService = PlaycutMetadataService(tokenProvider: MusicShareKit.authService)
     
@@ -116,6 +118,7 @@ struct PlaycutDetailView: View {
             ))
         }
         .task {
+            await loadArtworkIfNeeded()
             await loadMetadata()
         }
         .overlay {
@@ -135,6 +138,20 @@ struct PlaycutDetailView: View {
         .overlaySheetLightboxActive(isLightboxActive)
     }
     
+    private func loadArtworkIfNeeded() async {
+        guard artwork == nil, let artworkService else { return }
+        do {
+            let cgImage = try await artworkService.fetchArtwork(for: playcut)
+            await MainActor.run {
+                withAnimation(.easeInOut(duration: 0.25)) {
+                    self.artwork = cgImage.toUIImage()
+                }
+            }
+        } catch {
+            // Artwork fetch is best-effort
+        }
+    }
+
     private func loadMetadata() async {
         // If the playcut carries inline metadata from the v2 flowsheet response, use it directly
         if playcut.hasV2Metadata {

--- a/WXYC/iOS/Views/Playlist/SidebarPlaycutRow.swift
+++ b/WXYC/iOS/Views/Playlist/SidebarPlaycutRow.swift
@@ -1,0 +1,99 @@
+//
+//  SidebarPlaycutRow.swift
+//  WXYC
+//
+//  Simplified playcut row for use in sidebar List context. Displays a thumbnail,
+//  song title, artist name, and time in a compact horizontal layout suitable for
+//  NavigationSplitView sidebars.
+//
+//  Created by Jake Bromberg on 04/09/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Artwork
+import Playlist
+import SwiftUI
+import UIKit
+import WXUI
+
+struct SidebarPlaycutRow: View {
+    let playcut: Playcut
+
+    @State private var artwork: UIImage?
+    @State private var isLoadingArtwork = true
+
+    @Environment(\.artworkService) private var artworkService
+
+    var body: some View {
+        HStack(spacing: 10) {
+            artworkThumbnail
+                .frame(width: 44, height: 44)
+                .clipShape(.rect(cornerRadius: 4))
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(playcut.songTitle)
+                    .bold()
+                    .lineLimit(1)
+
+                Text(playcut.artistName)
+                    .lineLimit(1)
+
+                ClockView(timeCreated: playcut.timeCreated)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+        }
+        .foregroundStyle(.white)
+        .task {
+            await loadArtwork()
+        }
+    }
+
+    @ViewBuilder
+    private var artworkThumbnail: some View {
+        if let artwork {
+            Image(uiImage: artwork)
+                .resizable()
+                .aspectRatio(contentMode: .fill)
+        } else if isLoadingArtwork {
+            RoundedRectangle(cornerRadius: 4)
+                .fill(.primary.opacity(0.1))
+        } else {
+            PlaceholderArtworkView(cornerRadius: 4, shadowYOffset: 0)
+        }
+    }
+
+    private func loadArtwork() async {
+        guard let artworkService else {
+            isLoadingArtwork = false
+            return
+        }
+        do {
+            let cgImage = try await artworkService.fetchArtwork(for: playcut)
+            withAnimation(.easeInOut(duration: 0.25)) {
+                self.artwork = cgImage.toUIImage()
+                self.isLoadingArtwork = false
+            }
+        } catch {
+            isLoadingArtwork = false
+        }
+    }
+}
+
+#Preview {
+    List {
+        SidebarPlaycutRow(
+            playcut: Playcut(
+                id: 1,
+                hour: 1706544000000,
+                chronOrderID: 1,
+                timeCreated: 1706549400000,
+                songTitle: "VI Scose Poise",
+                labelName: "Warp",
+                artistName: "Autechre",
+                releaseTitle: "Confield"
+            )
+        )
+    }
+    .listStyle(.sidebar)
+}

--- a/WXYC/iOS/Views/Root/AdaptiveRootView.swift
+++ b/WXYC/iOS/Views/Root/AdaptiveRootView.swift
@@ -1,0 +1,24 @@
+//
+//  AdaptiveRootView.swift
+//  WXYC
+//
+//  Adaptive root view that branches between the compact phone layout (RootTabView)
+//  and a NavigationSplitView-based layout for regular horizontal size class (iPad, Mac).
+//
+//  Created by Jake Bromberg on 04/09/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import SwiftUI
+
+struct AdaptiveRootView: View {
+    @Environment(\.horizontalSizeClass) private var sizeClass
+
+    var body: some View {
+        if sizeClass == .compact {
+            RootTabView()
+        } else {
+            RegularLayoutView()
+        }
+    }
+}

--- a/WXYC/iOS/Views/Root/RegularLayoutView.swift
+++ b/WXYC/iOS/Views/Root/RegularLayoutView.swift
@@ -40,11 +40,11 @@ struct RegularLayoutView: View {
             detailContent
         }
         .animation(.easeInOut(duration: 0.2), value: selectedPlaycutID)
-        #if targetEnvironment(macCatalyst)
-        .onExitCommand {
+        .onKeyPress(.escape) {
+            guard selectedPlaycutID != nil else { return .ignored }
             selectedPlaycutID = nil
+            return .handled
         }
-        #endif
         .task {
             guard let playlistService else { return }
             for await playlist in playlistService.updates() {

--- a/WXYC/iOS/Views/Root/RegularLayoutView.swift
+++ b/WXYC/iOS/Views/Root/RegularLayoutView.swift
@@ -36,9 +36,13 @@ struct RegularLayoutView: View {
     var body: some View {
         NavigationSplitView {
             sidebarContent
+                .toolbarBackground(.hidden, for: .navigationBar)
         } detail: {
             detailContent
+                .toolbarBackground(.hidden, for: .navigationBar)
+                .background(.clear)
         }
+        .navigationSplitViewStyle(.balanced)
         .animation(.easeInOut(duration: 0.2), value: selectedPlaycutID)
         .onKeyPress(.escape) {
             guard selectedPlaycutID != nil else { return .ignored }

--- a/WXYC/iOS/Views/Root/RegularLayoutView.swift
+++ b/WXYC/iOS/Views/Root/RegularLayoutView.swift
@@ -1,0 +1,182 @@
+//
+//  RegularLayoutView.swift
+//  WXYC
+//
+//  NavigationSplitView-based layout for regular horizontal size class (iPad, Mac).
+//  Sidebar shows the player header, playlist, and info actions. Detail column shows
+//  the selected playcut or an empty-state placeholder.
+//
+//  Created by Jake Bromberg on 04/09/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import AppServices
+import Artwork
+import Playlist
+import PlayerHeaderView
+import SwiftUI
+import UIKit
+import Wallpaper
+import WXUI
+
+struct RegularLayoutView: View {
+    @State private var selectedPlaycutID: Playcut.ID?
+    @State private var playlistEntries: [any PlaylistEntry] = []
+    @State private var visualizer = VisualizerDataSource()
+
+    @Environment(\.playlistService) private var playlistService
+    @Environment(\.isThemePickerActive) private var isThemePickerActive
+    @Environment(\.themeAppearance) private var appearance
+    @Environment(Singletonia.self) private var appState
+
+    private var selectedPlaycut: Playcut? {
+        Self.findPlaycut(id: selectedPlaycutID, in: playlistEntries)
+    }
+
+    var body: some View {
+        NavigationSplitView {
+            sidebarContent
+        } detail: {
+            detailContent
+        }
+        .animation(.easeInOut(duration: 0.2), value: selectedPlaycutID)
+        #if targetEnvironment(macCatalyst)
+        .onExitCommand {
+            selectedPlaycutID = nil
+        }
+        #endif
+        .task {
+            guard let playlistService else { return }
+            for await playlist in playlistService.updates() {
+                withAnimation {
+                    self.playlistEntries = playlist.entries
+                }
+                // Clear stale selection
+                if let id = selectedPlaycutID,
+                   !playlist.entries.contains(where: { ($0 as? Playcut)?.id == id }) {
+                    selectedPlaycutID = nil
+                }
+            }
+        }
+        .themePickerGesture(
+            pickerState: appState.themePickerState,
+            configuration: appState.themeConfiguration
+        )
+    }
+
+    // MARK: - Sidebar
+
+    private var sidebarContent: some View {
+        VStack(spacing: 0) {
+            PlayerHeaderView(
+                visualizer: visualizer,
+                onDebugTapped: {}
+            )
+            .lcdAccentColor(appearance.accentColor)
+            .lcdHSBOffsets(
+                min: appearance.lcdMinOffset,
+                max: appearance.lcdMaxOffset
+            )
+            .lcdActiveBrightness(appearance.lcdActiveBrightness)
+
+            List(selection: $selectedPlaycutID) {
+                ForEach(Array(playlistEntries.enumerated()), id: \.element.id) { index, entry in
+                    let playcutIndex = playcutIndex(for: index)
+
+                    if playcutIndex == 0 {
+                        PlaylistSectionHeader(text: "now playing")
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    } else if playcutIndex == 1 {
+                        PlaylistSectionHeader(text: "recently played")
+                            .listRowBackground(Color.clear)
+                            .listRowSeparator(.hidden)
+                    }
+
+                    sidebarRow(for: entry)
+                }
+
+                SidebarInfoSection()
+            }
+            .listStyle(.sidebar)
+            .scrollContentBackground(.hidden)
+        }
+    }
+
+    @ViewBuilder
+    private func sidebarRow(for entry: any PlaylistEntry) -> some View {
+        switch entry {
+        case let playcut as Playcut:
+            SidebarPlaycutRow(playcut: playcut)
+                .tag(playcut.id)
+                .listRowBackground(Color.clear)
+
+        case let breakpoint as Breakpoint:
+            Text(breakpoint.formattedDate.uppercased())
+                .font(.caption.bold().smallCaps())
+                .foregroundStyle(.secondary)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+
+        case _ as Talkset:
+            Text("Talkset".uppercased())
+                .font(.caption.bold().smallCaps())
+                .foregroundStyle(.secondary)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+
+        case let showMarker as ShowMarker:
+            Text(showMarkerText(for: showMarker).uppercased())
+                .font(.caption.bold().smallCaps())
+                .foregroundStyle(.secondary)
+                .listRowBackground(Color.clear)
+                .listRowSeparator(.hidden)
+
+        default:
+            EmptyView()
+        }
+    }
+
+    // MARK: - Detail
+
+    @ViewBuilder
+    private var detailContent: some View {
+        if let playcut = selectedPlaycut {
+            ScrollView {
+                PlaycutDetailView(playcut: playcut, artwork: nil)
+                    .id(playcut.id)
+            }
+            .scrollIndicators(.hidden)
+            .frame(maxWidth: 600)
+            .frame(maxWidth: .infinity)
+        } else {
+            ContentUnavailableView(
+                "Select a Track",
+                systemImage: "music.note",
+                description: Text("Choose a track from the playlist to see details")
+            )
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Pure function for testability. Finds a playcut by ID in a list of playlist entries.
+    static func findPlaycut(id: Playcut.ID?, in entries: [any PlaylistEntry]) -> Playcut? {
+        guard let id else { return nil }
+        return entries.compactMap { $0 as? Playcut }.first { $0.id == id }
+    }
+
+    private func showMarkerText(for marker: ShowMarker) -> String {
+        if let djName = marker.djName {
+            marker.isStart ? "\(djName) signed on" : "\(djName) signed off"
+        } else {
+            marker.isStart ? "Signed on" : "Signed off"
+        }
+    }
+
+    /// Returns the playcut index (0-based) if the entry at the given index is a Playcut, or nil otherwise.
+    private func playcutIndex(for index: Int) -> Int? {
+        guard playlistEntries[index] is Playcut else { return nil }
+        return playlistEntries[..<index].filter { $0 is Playcut }.count
+    }
+}

--- a/WXYC/iOS/WXYCApp.swift
+++ b/WXYC/iOS/WXYCApp.swift
@@ -108,7 +108,7 @@ struct WXYCApp: App {
                 pickerState: appState.themePickerState
             ) {
                 ZStack {
-                    RootTabView()
+                    AdaptiveRootView()
                         .environment(appState)
                         .environment(\.playlistService, appState.playlistService)
                         .environment(\.artworkService, appState.artworkService)
@@ -533,7 +533,7 @@ struct WXYCApp: App {
         configuration: ThemeConfiguration(),
         pickerState: ThemePickerState()
     ) {
-        RootTabView()
+        AdaptiveRootView()
             .environment(\.playlistService, .preview)
             .environment(\.artworkService, .preview)
             .environment(\.playbackController, AudioPlayerController.shared)


### PR DESCRIPTION
## Summary

- Add size-class-aware root view: NavigationSplitView on iPad/Mac, existing phone UI on iPhone
- Sidebar contains player header, selectable playlist, and info/settings section
- Detail column shows playcut detail or "Select a Track" placeholder
- PlaycutDetailView enhanced to self-load artwork from artworkService
- Selection logic extracted as testable static function with 6 tests

Closes #197

## Test plan

- [ ] Run on iPhone simulator — verify phone UI is identical to before (paged tabs, overlay sheet)
- [ ] Run on iPad landscape — verify NavigationSplitView with sidebar and detail column
- [ ] Tap a playcut in sidebar — verify detail view appears with crossfade
- [ ] Tap a different playcut — verify detail swaps
- [ ] Run on Mac Catalyst — verify split view, press Escape to deselect
- [ ] Verify "Select a Track" placeholder shows when nothing is selected
- [ ] Verify info section buttons work (feedback, request, dial, merch) in sidebar
- [ ] Run AdaptiveLayoutTests (blocked by pre-existing CachingTests MockCache issue)