### PR TITLE
Guard playback on audio session activation failure

### DIFF
--- a/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
+++ b/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
@@ -229,7 +229,13 @@ public final class AudioPlayerController {
         stallStartTime = nil
         playbackStartTime = playbackStartTime ?? Date()
         #if os(iOS) || os(tvOS)
-        activateAudioSession()
+        guard activateAudioSession() else {
+            Log(.error, category: .playback, "Aborting play: audio session activation failed")
+            playbackIntended = false
+            playbackStartTime = nil
+            cpuAggregator?.endSession(reason: .error)
+            return
+        }
         #endif
 
         // Always play fresh for live streaming (don't resume paused state)
@@ -354,16 +360,21 @@ public final class AudioPlayerController {
         }
     }
 
-    private func activateAudioSession() {
-        guard let session = audioSession else { return }
+    /// Activates the audio session, returning whether activation succeeded.
+    /// - Returns: `true` if the session was activated (or no session exists), `false` on failure.
+    @discardableResult
+    private func activateAudioSession() -> Bool {
+        guard let session = audioSession else { return true }
         // Configure the audio session category if not already done
         configureAudioSessionIfNeeded()
         do {
             try session.setActive(true, options: [])
             audioSessionActivated = true
             Log(.info, category: .playback, "Audio session activated")
+            return true
         } catch {
             Log(.error, category: .playback, "Failed to activate audio session: \(error)")
+            return false
         }
     }
 
@@ -784,6 +795,13 @@ extension AudioPlayerController {
                 try await Task.sleep(for: .seconds(waitTime))
                 guard !Task.isCancelled else { return }
 
+                #if os(iOS) || os(tvOS)
+                guard self.activateAudioSession() else {
+                    Log(.error, category: .playback, "Reconnect aborted: audio session activation failed")
+                    self.backoffTimer.reset()
+                    return
+                }
+                #endif
                 self.player.play()
 
                 // Brief grace period for connection to establish

--- a/Shared/Playback/Tests/PlaybackTests/AudioPlayerControllerTests.swift
+++ b/Shared/Playback/Tests/PlaybackTests/AudioPlayerControllerTests.swift
@@ -103,6 +103,32 @@ struct AudioPlayerControllerTests {
         #expect(mockSession.setActiveCallCount == 3)
     }
 
+    // MARK: - Audio Session Failure Guard
+
+    @Test("Play bails when audio session activation fails")
+    func playBailsOnSessionActivationFailure() {
+        let mockSession = MockAudioSession()
+        let mockCommandCenter = MockRemoteCommandCenter()
+        let mockPlayer = MockAudioPlayerForController()
+
+        let controller = AudioPlayerController(
+            player: mockPlayer,
+            audioSession: mockSession,
+            remoteCommandCenter: mockCommandCenter,
+            notificationCenter: .default,
+            analytics: MockStructuredAnalytics()
+        )
+
+        mockSession.shouldThrowOnSetActive = true
+
+        controller.play()
+
+        #expect(controller.isPlaying == false)
+        // isLoading is false when playbackIntended is false (playerState is .idle)
+        #expect(controller.isLoading == false)
+        #expect(mockPlayer.isPlaying == false)
+    }
+
     // MARK: - Output Latency Tests
 
     @Test("Output latency returns audio session's output latency")


### PR DESCRIPTION
## Summary

- `activateAudioSession()` now returns `Bool` indicating success (marked `@discardableResult` so callers like `handleAppWillEnterForeground` don't need changes)
- `play(reason:)` bails out early when activation fails, preventing the downstream cascade where the MP3 stream connects but the audio engine can't start
- `attemptReconnectWithExponentialBackoff()` also guards on session activation before calling `player.play()`, closing the same hole in the reconnect path
- Added test using `MockAudioSession.shouldThrowOnSetActive` to verify the guard

Closes #199

## Test plan

- [x] `playBailsOnSessionActivationFailure` test covers the new guard path
- [ ] All Playback tests pass (`swift test` in `Shared/Playback`)
- [ ] Normal foreground play/stop cycles unaffected