### PR TITLE
Fix visualizer dying on second play session

### DIFF
--- a/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
+++ b/Shared/AppServices/Tests/AppServicesTests/WidgetStateServiceRelevanceTests.swift
@@ -156,7 +156,7 @@ final class MockPlaybackController: PlaybackController {
     func toggle(reason: PlaybackReason) throws {}
     func stop(reason: PlaybackReason) {}
 
-    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
+    func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
         AsyncStream { _ in }
     }
 

--- a/Shared/Playback/Sources/HLSPlayer/HLSPlayer.swift
+++ b/Shared/Playback/Sources/HLSPlayer/HLSPlayer.swift
@@ -74,7 +74,10 @@ public final class HLSPlayer: Sendable {
     public let stateStream: AsyncStream<PlayerState>
     private let stateContinuation: AsyncStream<PlayerState>.Continuation
 
-    public let audioBufferStream: AsyncStream<AVAudioPCMBuffer>
+    /// Creates a fresh stream of audio buffers (always empty for HLS player).
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
+    }
 
     public let eventStream: AsyncStream<AudioPlayerInternalEvent>
     private let eventContinuation: AsyncStream<AudioPlayerInternalEvent>.Continuation
@@ -106,10 +109,6 @@ public final class HLSPlayer: Sendable {
             stateContinuation = continuation
         }
         self.stateContinuation = stateContinuation
-
-        self.audioBufferStream = AsyncStream { continuation in
-            continuation.finish()
-        }
 
         var eventContinuation: AsyncStream<AudioPlayerInternalEvent>.Continuation!
         self.eventStream = AsyncStream { continuation in

--- a/Shared/Playback/Sources/MP3Streamer/MP3Streamer.swift
+++ b/Shared/Playback/Sources/MP3Streamer/MP3Streamer.swift
@@ -22,9 +22,10 @@ import Analytics
 public final class MP3Streamer {
     // MARK: - Streams
 
-    /// Stream of audio buffers for visualization - yields at render rate (~60 times/sec)
-    public var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
-        audioPlayer.renderTapStream
+    /// Creates a fresh stream of audio buffers for visualization.
+    /// Yields at render rate (~60 times/sec). Each call returns a new stream.
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        audioPlayer.makeRenderTapStream()
     }
 
     // MARK: - AudioPlayerProtocol Streams

--- a/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayer.swift
+++ b/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayer.swift
@@ -44,10 +44,9 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
     let eventStream: AsyncStream<AudioPlayerEvent>
     private let eventContinuation: AsyncStream<AudioPlayerEvent>.Continuation
 
-    /// Stream of audio buffers from the render tap.
-    /// Only yields buffers when tap is installed via `installRenderTap()`.
-    let renderTapStream: AsyncStream<AVAudioPCMBuffer>
-    private let renderTapContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation
+    /// Relay that manages mutable render tap continuations, allowing fresh streams
+    /// to be created across play sessions without the single-use AsyncStream limitation.
+    private let renderTapRelay = RenderTapRelay()
 
     /// Tracks whether the render tap is currently installed
     private let renderTapState: RenderTapState
@@ -87,11 +86,6 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
         self.eventStream = AsyncStream(bufferingPolicy: .bufferingNewest(16)) { eventCont = $0 }
         self.eventContinuation = eventCont
 
-        // Initialize render tap stream - only keeps latest buffer for visualization
-        var renderCont: AsyncStream<AVAudioPCMBuffer>.Continuation!
-        self.renderTapStream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { renderCont = $0 }
-        self.renderTapContinuation = renderCont
-
         // NOTE: We intentionally do NOT call setUpAudioEngine() here.
         // Accessing engine.mainMixerNode during init implicitly activates the audio
         // hardware and interrupts other apps' audio. Setup is deferred until play().
@@ -108,9 +102,9 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
         // Install any pending render tap that was requested before engine was ready
         if pendingRenderTapState.remove() {
             guard renderTapState.install() else { return }
-            let continuation = renderTapContinuation
+            let relay = renderTapRelay
             playerNode.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
-                continuation.yield(buffer)
+                relay.yield(buffer)
             }
         }
 
@@ -165,9 +159,9 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
         guard renderTapState.install() else { return } // Already installed
 
         Log(.info, category: .playback, "Render tap installed")
-        let continuation = renderTapContinuation
+        let relay = renderTapRelay
         playerNode.installTap(onBus: 0, bufferSize: 2048, format: format) { buffer, _ in
-            continuation.yield(buffer)
+            relay.yield(buffer)
         }
     }
 
@@ -176,6 +170,10 @@ final class AudioEnginePlayer: AudioEnginePlayerProtocol, @unchecked Sendable {
 
         Log(.info, category: .playback, "Render tap removed")
         playerNode.removeTap(onBus: 0)
+    }
+
+    func makeRenderTapStream() -> AsyncStream<AVAudioPCMBuffer> {
+        renderTapRelay.makeStream()
     }
 
     func play() throws {
@@ -486,6 +484,48 @@ private final class EngineSetUpState: @unchecked Sendable {
         os_unfair_lock_lock(lock)
         defer { os_unfair_lock_unlock(lock) }
         _isSetUp = false
+    }
+}
+
+/// Manages a mutable AsyncStream continuation for the render tap, allowing
+/// fresh streams to be created across play sessions. AsyncStream is single-use:
+/// once a consumer's iterator is deallocated, the stream terminates permanently.
+/// This relay solves the problem by finishing the old continuation and creating
+/// a new stream+continuation pair on each `makeStream()` call.
+private final class RenderTapRelay: @unchecked Sendable {
+    private let lock: UnsafeMutablePointer<os_unfair_lock>
+    private var _continuation: AsyncStream<AVAudioPCMBuffer>.Continuation?
+
+    init() {
+        lock = .allocate(capacity: 1)
+        lock.initialize(to: os_unfair_lock())
+    }
+
+    deinit {
+        lock.deinitialize(count: 1)
+        lock.deallocate()
+    }
+
+    /// Creates a fresh AsyncStream, finishing any previously active continuation.
+    func makeStream() -> AsyncStream<AVAudioPCMBuffer> {
+        os_unfair_lock_lock(lock)
+        let old = _continuation
+        var newCont: AsyncStream<AVAudioPCMBuffer>.Continuation!
+        let stream = AsyncStream<AVAudioPCMBuffer>(bufferingPolicy: .bufferingNewest(1)) { newCont = $0 }
+        _continuation = newCont
+        os_unfair_lock_unlock(lock)
+        old?.finish()
+        return stream
+    }
+
+    /// Yields a buffer to the current continuation, if any.
+    /// The lock protects only the pointer read; the actual yield happens outside
+    /// the lock to keep the critical section minimal for the audio thread.
+    func yield(_ buffer: AVAudioPCMBuffer) {
+        os_unfair_lock_lock(lock)
+        let cont = _continuation
+        os_unfair_lock_unlock(lock)
+        cont?.yield(buffer)
     }
 }
 

--- a/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayerProtocol.swift
+++ b/Shared/Playback/Sources/MP3Streamer/Playback/AudioEnginePlayerProtocol.swift
@@ -41,9 +41,10 @@ public protocol AudioEnginePlayerProtocol: AnyObject, Sendable {
     /// Stream of player events
     var eventStream: AsyncStream<AudioPlayerEvent> { get }
 
-    /// Stream of audio buffers from the render tap for visualization.
+    /// Creates a fresh stream of audio buffers from the render tap for visualization.
+    /// Each call returns a new stream; the previous stream's continuation is finished.
     /// Only yields buffers when the tap is installed via `installRenderTap()`.
-    var renderTapStream: AsyncStream<AVAudioPCMBuffer> { get }
+    func makeRenderTapStream() -> AsyncStream<AVAudioPCMBuffer>
 
     /// Start playback
     func play() throws

--- a/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
+++ b/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
@@ -668,9 +668,10 @@ public final class AudioPlayerController {
 // MARK: - Convenience for views
 
 extension AudioPlayerController {
-    /// Stream of audio buffers for visualization
-    public var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
-        player.audioBufferStream
+    /// Creates a fresh stream of audio buffers for visualization.
+    /// Each call returns a new stream; the previous stream's continuation is finished.
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        player.makeAudioBufferStream()
     }
 
     #if os(iOS) || os(tvOS)

--- a/Shared/Playback/Sources/PlaybackCore/Protocols/AudioPlayerProtocol.swift
+++ b/Shared/Playback/Sources/PlaybackCore/Protocols/AudioPlayerProtocol.swift
@@ -36,10 +36,11 @@ public protocol AudioPlayerProtocol: AnyObject {
     /// Stream of player state changes
     var stateStream: AsyncStream<PlayerState> { get }
     
-    /// Stream of audio buffers for visualization
-    /// Should be buffered with .bufferingNewest(1) to avoid blocking audio thread
-    /// Note: Only yields buffers when render tap is installed via `installRenderTap()`
-    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> { get }
+    /// Creates a fresh stream of audio buffers for visualization.
+    /// Each call returns a new stream; the previous stream's continuation is finished.
+    /// Should be buffered with .bufferingNewest(1) to avoid blocking audio thread.
+    /// Only yields buffers when render tap is installed via `installRenderTap()`.
+    func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer>
 
     /// Stream of internal player events (errors, stalls, recovery)
     var eventStream: AsyncStream<AudioPlayerInternalEvent> { get }

--- a/Shared/Playback/Sources/PlaybackCore/Protocols/PlaybackController.swift
+++ b/Shared/Playback/Sources/PlaybackCore/Protocols/PlaybackController.swift
@@ -54,11 +54,12 @@ public protocol PlaybackController: AnyObject, Observable {
     /// - Parameter reason: Why playback was stopped (for analytics)
     func stop(reason: PlaybackReason)
     
-    /// Stream of audio buffers for visualization
-    /// Controllers without audio buffer access should return an empty stream
-    /// Should be buffered with .bufferingNewest(1) to avoid blocking audio thread
-    /// Note: Only yields buffers when render tap is installed via `installRenderTap()`
-    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> { get }
+    /// Creates a fresh stream of audio buffers for visualization.
+    /// Each call returns a new stream; the previous stream's continuation is finished.
+    /// Controllers without audio buffer access should return an empty finished stream.
+    /// Should be buffered with .bufferingNewest(1) to avoid blocking audio thread.
+    /// Only yields buffers when render tap is installed via `installRenderTap()`.
+    func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer>
 
     /// Install the render tap for audio visualization.
     /// The tap runs at ~60Hz and consumes CPU, so only install when actively displaying visualizations.

--- a/Shared/Playback/Sources/RadioPlayer/Controller/RadioPlayerController.swift
+++ b/Shared/Playback/Sources/RadioPlayer/Controller/RadioPlayerController.swift
@@ -236,12 +236,10 @@ public final class RadioPlayerController: PlaybackController {
         self.state = .idle
     }
     
-    public var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
         // RadioPlayerController uses AVPlayer which doesn't provide raw audio buffers
         // Return empty stream that finishes immediately
-        AsyncStream { continuation in
-            continuation.finish()
-        }
+        AsyncStream { $0.finish() }
     }
     
     /// No-op: AVPlayer-based RadioPlayerController doesn't support render tap

--- a/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer+AudioPlayerProtocol.swift
+++ b/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer+AudioPlayerProtocol.swift
@@ -16,8 +16,8 @@ import PlaybackCore
 
 extension RadioPlayer: AudioPlayerProtocol {
 
-    // RadioPlayer now provides state, stateStream, audioBufferStream, and eventStream
-    // as stored properties, so only the missing protocol methods need to be added here.
+    // RadioPlayer now provides state, stateStream, makeAudioBufferStream(), and eventStream
+    // directly, so only the missing protocol methods need to be added here.
 
     public func stop() {
         pause()

--- a/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer.swift
+++ b/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer.swift
@@ -48,8 +48,10 @@ public final class RadioPlayer: Sendable {
     public let stateStream: AsyncStream<PlayerState>
     private let stateContinuation: AsyncStream<PlayerState>.Continuation
         
-    /// Stream of audio buffers (not supported by AVPlayer-based RadioPlayer)
-    public let audioBufferStream: AsyncStream<AVAudioPCMBuffer>
+    /// Creates a fresh stream of audio buffers (always empty for AVPlayer-based RadioPlayer).
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
+    }
 
     /// Stream of internal player events (stalls, recovery, errors)
     public let eventStream: AsyncStream<AudioPlayerInternalEvent>
@@ -85,11 +87,6 @@ public final class RadioPlayer: Sendable {
             stateContinuation = continuation
         }
         self.stateContinuation = stateContinuation
-
-        // Initialize audio buffer stream (empty - AVPlayer doesn't expose PCM buffers)
-        self.audioBufferStream = AsyncStream { continuation in
-            continuation.finish()
-        }
 
         // Initialize event stream
         var eventContinuation: AsyncStream<AudioPlayerInternalEvent>.Continuation!

--- a/Shared/Playback/Tests/HLSPlayerTests/HLSPlayerTests.swift
+++ b/Shared/Playback/Tests/HLSPlayerTests/HLSPlayerTests.swift
@@ -162,7 +162,7 @@ struct HLSPlayerTests {
         let (player, _, _) = makePlayer()
         var count = 0
 
-        for await _ in player.audioBufferStream {
+        for await _ in player.makeAudioBufferStream() {
             count += 1
         }
 

--- a/Shared/Playback/Tests/MP3StreamerTests/AudioEnginePlayerTests.swift
+++ b/Shared/Playback/Tests/MP3StreamerTests/AudioEnginePlayerTests.swift
@@ -498,6 +498,74 @@ struct AudioEnginePlayerTests {
 
         player.stop()
     }
+
+    // MARK: - Render Tap Stream Reuse Tests
+
+    @Test("makeRenderTapStream returns a working stream after previous consumer is cancelled")
+    func testMakeRenderTapStreamAfterCancellation() async throws {
+        let format = TestAudioBufferFactory.makeStandardFormat()
+        let player = AudioEnginePlayer(format: format)
+
+        // Set up engine and install render tap
+        try player.play()
+        _ = try await player.eventStream.first(timeout: 2) // Consume started
+        player.installRenderTap()
+
+        // First stream: consume one buffer then cancel
+        let firstStream = player.makeRenderTapStream()
+        let buffer1 = TestAudioBufferFactory.makeSilentBuffer(frameCount: 2048)
+        player.scheduleBuffer(buffer1)
+
+        let firstTask = Task {
+            for await _ in firstStream {
+                return true
+            }
+            return false
+        }
+
+        let received = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask { await firstTask.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(2))
+                throw TimeoutError()
+            }
+            guard let result = try await group.next() else { throw TimeoutError() }
+            group.cancelAll()
+            return result
+        }
+        #expect(received, "First stream should receive a buffer")
+
+        // Cancel the first consumer
+        firstTask.cancel()
+        try await Task.sleep(for: .milliseconds(50))
+
+        // Second stream: should work after the first was cancelled
+        let secondStream = player.makeRenderTapStream()
+        let buffer2 = TestAudioBufferFactory.makeSilentBuffer(frameCount: 2048)
+        player.scheduleBuffer(buffer2)
+
+        let secondTask = Task {
+            for await _ in secondStream {
+                return true
+            }
+            return false
+        }
+
+        let receivedAgain = try await withThrowingTaskGroup(of: Bool.self) { group in
+            group.addTask { await secondTask.value }
+            group.addTask {
+                try await Task.sleep(for: .seconds(2))
+                throw TimeoutError()
+            }
+            guard let result = try await group.next() else { throw TimeoutError() }
+            group.cancelAll()
+            return result
+        }
+        #expect(receivedAgain, "Second stream should receive a buffer after first stream was cancelled")
+
+        secondTask.cancel()
+        player.stop()
+    }
 }
 
 // MARK: - Additional Test Tags

--- a/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioEnginePlayer.swift
+++ b/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioEnginePlayer.swift
@@ -20,11 +20,10 @@ import AnalyticsTesting
 @MainActor
 public final class MockAudioEnginePlayer: @preconcurrency AudioEnginePlayerProtocol {
     private let eventContinuation: AsyncStream<AudioPlayerEvent>.Continuation
-    private let renderContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation
+    private var renderContinuation: AsyncStream<AVAudioPCMBuffer>.Continuation
     public let analytics: MockStructuredAnalytics?
 
     public let eventStream: AsyncStream<AudioPlayerEvent>
-    public let renderTapStream: AsyncStream<AVAudioPCMBuffer>
 
     public var volume: Float = 1.0
     public private(set) var isPlaying = false
@@ -51,8 +50,15 @@ public final class MockAudioEnginePlayer: @preconcurrency AudioEnginePlayerProto
         self.eventContinuation = eventCont
 
         var renderCont: AsyncStream<AVAudioPCMBuffer>.Continuation!
-        self.renderTapStream = AsyncStream(bufferingPolicy: .bufferingNewest(1)) { renderCont = $0 }
+        _ = AsyncStream<AVAudioPCMBuffer>(bufferingPolicy: .bufferingNewest(1)) { renderCont = $0 }
         self.renderContinuation = renderCont
+    }
+
+    public func makeRenderTapStream() -> AsyncStream<AVAudioPCMBuffer> {
+        var cont: AsyncStream<AVAudioPCMBuffer>.Continuation!
+        let stream = AsyncStream<AVAudioPCMBuffer>(bufferingPolicy: .bufferingNewest(1)) { cont = $0 }
+        self.renderContinuation = cont
+        return stream
     }
 
     public func play() throws {

--- a/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioPlayer.swift
+++ b/Shared/Playback/Tests/PlaybackTestUtilities/Mocks/MockAudioPlayer.swift
@@ -31,7 +31,6 @@ public final class MockAudioPlayer: AudioPlayerProtocol {
     public var state: PlayerState = .idle
 
     public let stateStream: AsyncStream<PlayerState>
-    public let audioBufferStream: AsyncStream<AVAudioPCMBuffer>
     public let eventStream: AsyncStream<AudioPlayerInternalEvent>
 
     public var onAudioBuffer: ((AVAudioPCMBuffer) -> Void)?
@@ -52,8 +51,6 @@ public final class MockAudioPlayer: AudioPlayerProtocol {
         var sC: AsyncStream<PlayerState>.Continuation!
         self.stateStream = AsyncStream { sC = $0 }
         self.stateContinuation = sC
-
-        self.audioBufferStream = AsyncStream { $0.finish() }
 
         var eC: AsyncStream<AudioPlayerInternalEvent>.Continuation!
         self.eventStream = AsyncStream { eC = $0 }
@@ -82,6 +79,10 @@ public final class MockAudioPlayer: AudioPlayerProtocol {
             onStateChange?(oldState, .idle)
             stateContinuation?.yield(.idle)
         }
+    }
+
+    public func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
     }
 
     public func installRenderTap() {

--- a/Shared/Playback/Tests/PlaybackTests/AudioPlayerControllerTests.swift
+++ b/Shared/Playback/Tests/PlaybackTests/AudioPlayerControllerTests.swift
@@ -231,10 +231,8 @@ final class MockAudioPlayerForController: AudioPlayerProtocol, @unchecked Sendab
         }
     }
 
-    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
-        AsyncStream { continuation in
-            continuation.finish()
-        }
+    func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
     }
 
     func play() {

--- a/Shared/Playback/Tests/PlaybackTests/Behavior/AudioPlayerBehaviorTests.swift
+++ b/Shared/Playback/Tests/PlaybackTests/Behavior/AudioPlayerBehaviorTests.swift
@@ -479,7 +479,7 @@ struct AudioPlayerAudioBufferStreamTests {
         let harness = AudioPlayerTestHarness.make(for: testCase)
 
         // Should have an audioBufferStream (even if it's empty for RadioPlayer)
-        let stream = harness.player.audioBufferStream
+        let stream = harness.player.makeAudioBufferStream()
         _ = stream // Just verify it exists
     }
 
@@ -488,7 +488,7 @@ struct AudioPlayerAudioBufferStreamTests {
         let harness = AudioPlayerTestHarness.make(for: testCase)
 
         var bufferCount = 0
-        for await _ in harness.player.audioBufferStream {
+        for await _ in harness.player.makeAudioBufferStream() {
             bufferCount += 1
         }
 
@@ -518,7 +518,7 @@ struct AudioPlayerProtocolConformanceTests {
         _ = harness.player.isPlaying
         _ = harness.player.state
         _ = harness.player.stateStream
-        _ = harness.player.audioBufferStream
+        _ = harness.player.makeAudioBufferStream()
         _ = harness.player.eventStream
         harness.player.play()
         harness.player.stop()

--- a/Shared/Playback/Tests/PlaybackTests/ObservationIntegrationTests.swift
+++ b/Shared/Playback/Tests/PlaybackTests/ObservationIntegrationTests.swift
@@ -231,10 +231,8 @@ final class ObservationTestMockPlayer: AudioPlayerProtocol, @unchecked Sendable 
         }
     }
 
-    var audioBufferStream: AsyncStream<AVAudioPCMBuffer> {
-        AsyncStream { continuation in
-            continuation.finish()
-        }
+    func makeAudioBufferStream() -> AsyncStream<AVAudioPCMBuffer> {
+        AsyncStream { $0.finish() }
     }
 
     func play() {

--- a/Shared/PlayerHeaderView/Sources/PlayerHeaderView/PlayerHeaderView.swift
+++ b/Shared/PlayerHeaderView/Sources/PlayerHeaderView/PlayerHeaderView.swift
@@ -80,7 +80,7 @@ public struct PlayerHeaderView: View {
         .onAppear {
             Self.controller.installRenderTap()
             if Self.controller.isPlaying {
-                visualizer.startConsuming(stream: Self.controller.audioBufferStream)
+                visualizer.startConsuming(stream: Self.controller.makeAudioBufferStream())
             }
         }
         .onDisappear {
@@ -89,7 +89,7 @@ public struct PlayerHeaderView: View {
         }
         .onChange(of: Self.controller.isPlaying) { _, nowPlaying in
             if nowPlaying {
-                visualizer.startConsuming(stream: Self.controller.audioBufferStream)
+                visualizer.startConsuming(stream: Self.controller.makeAudioBufferStream())
             } else {
                 visualizer.stopConsuming()
             }


### PR DESCRIPTION
## Summary

`AsyncStream` is single-use in Swift -- when a `for await` loop exits due to task cancellation, the stream is permanently terminated. The render tap stream was created once in `AudioEnginePlayer.init()` but the visualizer consumer canceled and recreated iterators across play sessions.

- Replace stored `renderTapStream`/`renderTapContinuation` with `RenderTapRelay` (thread-safe mutable continuation holder using `os_unfair_lock`, matching existing patterns)
- Change `renderTapStream` property to `makeRenderTapStream()` factory method across the protocol chain (`AudioEnginePlayerProtocol` -> `AudioPlayerProtocol` -> `PlaybackController`)
- Each call creates a fresh `AsyncStream`; the relay yields to whichever continuation is current
- Update all implementors, mocks, and test stubs (19 files, mostly mechanical prop-to-method changes)

Closes #203

## Test plan

- [x] 240 Playback tests pass (`swift test` in `Shared/Playback`)
- [x] Full Xcode build succeeds
- [x] New test `testMakeRenderTapStreamAfterCancellation` verifies a second stream works after the first consumer was cancelled
- [ ] Manual: play, stop, play again -- visualizer should animate on both sessions