### PR TITLE
Enable MPTCP handover for seamless WiFi-to-cellular streaming

### DIFF
--- a/Shared/Playback/Sources/HLSPlayer/Protocol/HLSAVPlayerProtocol.swift
+++ b/Shared/Playback/Sources/HLSPlayer/Protocol/HLSAVPlayerProtocol.swift
@@ -37,7 +37,11 @@ final class AVPlayerHLSAdapter: HLSAVPlayerProtocol, @unchecked Sendable {
     private let player: AVPlayer
 
     init(url: URL) {
-        self.player = AVPlayer(playerItem: AVPlayerItem(url: url))
+        let asset = AVURLAsset(url: url, options: [
+            AVURLAssetAllowsConstrainedNetworkAccessKey: true,
+            AVURLAssetAllowsExpensiveNetworkAccessKey: true,
+        ])
+        self.player = AVPlayer(playerItem: AVPlayerItem(asset: asset))
     }
 
     var rate: Float { player.rate }

--- a/Shared/Playback/Sources/MP3Streamer/Streaming/HTTPStreamClient.swift
+++ b/Shared/Playback/Sources/MP3Streamer/Streaming/HTTPStreamClient.swift
@@ -43,6 +43,18 @@ final class HTTPStreamClient: HTTPStreamClientProtocol, @unchecked Sendable {
         self.continuation = cont
     }
 
+    /// Builds the URLSession configuration for streaming, with MPTCP handover enabled on iOS.
+    static func makeSessionConfiguration(for configuration: MP3StreamerConfiguration) -> URLSessionConfiguration {
+        let sessionConfig = URLSessionConfiguration.default
+        sessionConfig.timeoutIntervalForRequest = configuration.connectionTimeout
+        sessionConfig.timeoutIntervalForResource = 0 // No timeout for streaming
+        #if os(iOS)
+        sessionConfig.multipathServiceType = .handover
+        #endif
+        sessionConfig.waitsForConnectivity = true
+        return sessionConfig
+    }
+
     func connect() async throws {
         Log(.info, category: .playback, "Connecting to \(url.absoluteString)")
         // Cancel any existing connection
@@ -57,12 +69,7 @@ final class HTTPStreamClient: HTTPStreamClientProtocol, @unchecked Sendable {
         // Create delegate that receives data in chunks
         let delegate = StreamingDataDelegate(continuation: continuation)
 
-        // Create session with delegate - data arrives in chunks via delegate methods
-        let sessionConfig = URLSessionConfiguration.default
-        sessionConfig.timeoutIntervalForRequest = configuration.connectionTimeout
-        sessionConfig.timeoutIntervalForResource = 0 // No timeout for streaming
-        sessionConfig.waitsForConnectivity = false
-
+        let sessionConfig = Self.makeSessionConfiguration(for: configuration)
         let session = URLSession(configuration: sessionConfig, delegate: delegate, delegateQueue: nil)
         let dataTask = session.dataTask(with: request)
 

--- a/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer.swift
+++ b/Shared/Playback/Sources/RadioPlayer/Player/RadioPlayer.swift
@@ -60,9 +60,10 @@ public final class RadioPlayer: Sendable {
     // MARK: - Initialization
 
     public convenience init(streamURL: URL = RadioStation.WXYC.streamURL) {
+        let asset = AVURLAsset(url: streamURL, options: Self.streamingAssetOptions)
         self.init(
             streamURL: streamURL,
-            player: AVPlayer(url: streamURL),
+            player: AVPlayer(playerItem: AVPlayerItem(asset: asset)),
             analytics: StructuredPostHogAnalytics.shared,
             notificationCenter: .default
         )
@@ -171,8 +172,13 @@ public final class RadioPlayer: Sendable {
 
     private let player: PlayerProtocol
 
+    private static let streamingAssetOptions: [String: Any] = [
+        AVURLAssetAllowsConstrainedNetworkAccessKey: true,
+        AVURLAssetAllowsExpensiveNetworkAccessKey: true,
+    ]
+
     private func resetStream() {
-        let asset = AVURLAsset(url: self.streamURL)
+        let asset = AVURLAsset(url: self.streamURL, options: Self.streamingAssetOptions)
         let playerItem = AVPlayerItem(asset: asset)
         self.player.replaceCurrentItem(with: playerItem)
     }

--- a/Shared/Playback/Tests/MP3StreamerTests/HTTPStreamClientTests.swift
+++ b/Shared/Playback/Tests/MP3StreamerTests/HTTPStreamClientTests.swift
@@ -47,6 +47,19 @@ struct HTTPStreamClientTests {
         _ = client
     }
 
+    @Test("Session configuration enables MPTCP handover and waits for connectivity")
+    func testSessionConfigurationMultipath() {
+        let config = makeConfiguration()
+        let sessionConfig = HTTPStreamClient.makeSessionConfiguration(for: config)
+
+        #if os(iOS)
+        #expect(sessionConfig.multipathServiceType == .handover)
+        #endif
+        #expect(sessionConfig.waitsForConnectivity == true)
+        #expect(sessionConfig.timeoutIntervalForRequest == config.connectionTimeout)
+        #expect(sessionConfig.timeoutIntervalForResource == 0)
+    }
+
     @Test("HTTPStreamError cases are distinct")
     func testErrorCases() {
         let invalidURL = HTTPStreamError.invalidURL

--- a/WXYC/Entitlements/WXYC.entitlements
+++ b/WXYC/Entitlements/WXYC.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
 	<key>com.apple.developer.group-session</key>
 	<true/>
 	<key>com.apple.developer.siri</key>

--- a/WXYC/Entitlements/WXYCDebug.entitlements
+++ b/WXYC/Entitlements/WXYCDebug.entitlements
@@ -4,6 +4,8 @@
 <dict>
 	<key>com.apple.developer.carplay-audio</key>
 	<true/>
+	<key>com.apple.developer.networking.multipath</key>
+	<true/>
 	<key>com.apple.developer.group-session</key>
 	<true/>
 	<key>com.apple.developer.siri</key>


### PR DESCRIPTION
## Summary

- Add `com.apple.developer.networking.multipath` entitlement to enable Multipath TCP
- Configure `HTTPStreamClient` with `.handover` multipath service type and `waitsForConnectivity = true` so the session transitions to cellular instead of failing on WiFi loss
- Set `AVURLAssetAllowsConstrainedNetworkAccessKey` and `AVURLAssetAllowsExpensiveNetworkAccessKey` on all AVPlayer-based playback engines (RadioPlayer, HLSPlayer) so streams survive network transitions

Closes #205

## Test plan

- [x] `HTTPStreamClientTests` pass, including new `testSessionConfigurationMultipath`
- [x] Full app builds for iOS simulator
- [ ] Manual test: start stream on WiFi, walk out of range, verify stream recovers on cellular