### PR TITLE
Fix playlist artwork not loading

### DIFF
--- a/Shared/Artwork/Sources/Artwork/MultisourceArtworkService.swift
+++ b/Shared/Artwork/Sources/Artwork/MultisourceArtworkService.swift
@@ -119,6 +119,13 @@ public final actor MultisourceArtworkService: ArtworkService {
     private func scanFetchers(for playcut: Playcut) async -> CGImage? {
         let cacheKey = playcut.artworkCacheKey
 
+        // Check positive cache first. Artwork may have been stored by an external
+        // code path (e.g. metadata fallback in detail view) after a negative cache
+        // entry was recorded.
+        if let cached = try? await cacheCoordinator.fetchArtwork(for: playcut) {
+            return cached
+        }
+
         if let cachedError: Error = try? await self.errorCache.fetchError(for: cacheKey),
            Error.allCases.contains(cachedError) {
             Log(.info, category: .artwork, "Cached error for \(cacheKey): \(cachedError)")
@@ -157,6 +164,18 @@ public final actor MultisourceArtworkService: ArtworkService {
 
     private func removeTask(for id: String) {
         inflightTasks[id] = nil
+    }
+
+    /// Stores artwork fetched by an external code path (e.g. the metadata fallback
+    /// in the detail view) and clears any negative cache entry for the same key.
+    ///
+    /// Call this when artwork is loaded outside the normal fetcher chain so that
+    /// subsequent `fetchArtwork(for:)` calls find it in the positive cache.
+    public func cacheExternalArtwork(_ image: CGImage, for playcut: Playcut) async {
+        let cacheKey = playcut.artworkCacheKey
+        let lifespan: TimeInterval = playcut.rotation ? .thirtyDays : .oneDay
+        await cacheCoordinator.set(artwork: image, for: cacheKey, lifespan: lifespan)
+        await errorCache.setData(nil, for: cacheKey, lifespan: 0)
     }
 
     /// Clears cached "no artwork available" errors so entries are retried with the current fetcher chain.

--- a/Shared/Artwork/Tests/ArtworkTests/ArtworkServiceTests.swift
+++ b/Shared/Artwork/Tests/ArtworkTests/ArtworkServiceTests.swift
@@ -306,7 +306,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         // Two playcuts with same release title but DIFFERENT artists
@@ -341,7 +341,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         // Two playcuts with same song title but DIFFERENT artists, no release title
@@ -375,7 +375,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         // Two playcuts with same song title AND same artist, no release title
@@ -407,7 +407,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         let playcut1 = Playcut.stub(songTitle: "Song A", releaseTitle: "Album A")
@@ -517,7 +517,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         let playcut = Playcut.stub(
@@ -552,7 +552,7 @@ struct ArtworkServiceTests {
 
         let service = MultisourceArtworkService(
             fetchers: [fetcher],
-            cacheCoordinator: CacheCoordinator(cache: DiskCache())
+            cacheCoordinator: CacheCoordinator(cache: DiskCache(subdirectory: "test-\(UUID().uuidString)"))
         )
 
         let playcuts: [Playcut] = (1...5).map { i in
@@ -586,8 +586,8 @@ struct ArtworkServiceTests {
         #expect(fetcher.fetchCount == 5)
     }
 
-    @Test("Sequential requests for same artwork use cached task")
-    func sequentialRequestsUseCachedTask() async throws {
+    @Test("Sequential requests for same artwork serve from positive cache after first fetch")
+    func sequentialRequestsServeFromCache() async throws {
         // Given
         let fetcher = MockArtworkService()
         let artwork = CGImage.testImageWithColor(.systemIndigo)
@@ -605,9 +605,9 @@ struct ArtworkServiceTests {
         _ = try await service.fetchArtwork(for: playcut)
         _ = try await service.fetchArtwork(for: playcut)
 
-        // Then - Each sequential request hits the fetcher because the in-flight task
-        // is removed between calls (no cache fetcher in the fetchers list)
-        #expect(fetcher.fetchCount == 3)
+        // Then - First call hits the fetcher and caches the result;
+        // subsequent calls serve from the positive cache
+        #expect(fetcher.fetchCount == 1)
     }
 
     // MARK: - Default Initializer Test
@@ -673,6 +673,65 @@ struct ArtworkServiceTests {
         // Second call: should retry (not cached), so fetcher count increases
         do { _ = try await service.fetchArtwork(for: playcut) } catch {}
         #expect(fetcher.fetchCount == 2)
+    }
+
+    @Test("Positive cache takes precedence over negative cache")
+    func positiveCacheTakesPrecedenceOverNegativeCache() async throws {
+        // Given: a service where all fetchers fail
+        let fetcher = MockArtworkService()
+        fetcher.errorToThrow = ServiceError.noResults
+
+        let artworkCache = CacheCoordinator(cache: DiskCache(subdirectory: "test-pos-\(UUID().uuidString)"))
+        let errorCache = CacheCoordinator(cache: DiskCache(subdirectory: "test-errors-\(UUID().uuidString)"))
+        let service = MultisourceArtworkService(
+            fetchers: [artworkCache, fetcher],
+            cacheCoordinator: artworkCache,
+            errorCache: errorCache
+        )
+
+        let playcut = uniquePlaycut()
+
+        // First call: fails and sets negative cache entry
+        do { _ = try await service.fetchArtwork(for: playcut) } catch {}
+
+        // Externally store artwork in positive cache (simulates detail view caching)
+        let testImage = CGImage.testImageWithColor(.green)
+        await artworkCache.set(artwork: testImage, for: playcut.artworkCacheKey, lifespan: .thirtyDays)
+
+        // When: fetching again with negative cache still present
+        // Then: positive cache should win
+        let result = try await service.fetchArtwork(for: playcut)
+        #expect(result.width > 0)
+    }
+
+    @Test("cacheExternalArtwork stores artwork and clears negative cache")
+    func cacheExternalArtworkStoresAndClearsNegativeCache() async throws {
+        // Given: a service where all fetchers fail
+        let fetcher = MockArtworkService()
+        fetcher.errorToThrow = ServiceError.noResults
+
+        let artworkCache = CacheCoordinator(cache: DiskCache(subdirectory: "test-ext-\(UUID().uuidString)"))
+        let errorCache = CacheCoordinator(cache: DiskCache(subdirectory: "test-errors-\(UUID().uuidString)"))
+        let service = MultisourceArtworkService(
+            fetchers: [artworkCache, fetcher],
+            cacheCoordinator: artworkCache,
+            errorCache: errorCache
+        )
+
+        let playcut = uniquePlaycut()
+
+        // First call: fails and sets negative cache entry
+        do { _ = try await service.fetchArtwork(for: playcut) } catch {}
+        #expect(fetcher.fetchCount == 1)
+
+        // When: store artwork externally
+        let testImage = CGImage.testImageWithColor(.cyan)
+        await service.cacheExternalArtwork(testImage, for: playcut)
+
+        // Then: fetch should succeed from cache without hitting the fetcher again
+        let result = try await service.fetchArtwork(for: playcut)
+        #expect(result.width > 0)
+        #expect(fetcher.fetchCount == 1) // fetcher not called again
     }
 
     @Test("clearNegativeCache allows retrying previously failed lookups")

--- a/WXYC/iOS/Singletonia.swift
+++ b/WXYC/iOS/Singletonia.swift
@@ -90,19 +90,36 @@ final class Singletonia {
     /// Call this early in the app lifecycle. The artwork service starts with cache + URL
     /// fetcher only; once secrets arrive with Discogs credentials, the Discogs API fallback
     /// is added to the fetcher chain. Requires device session auth.
+    ///
+    /// Retries with exponential backoff on failure because a transient timeout would
+    /// otherwise leave the Discogs fallback disabled for the entire session, causing
+    /// all artwork lookups to fail for v1 API entries (which have no inline artworkURL).
     func fetchConfiguration() async {
         let appConfiguration = AppConfiguration()
+        let maxAttempts = 4
+        var delay: Duration = .seconds(5)
 
-        guard let authService = MusicShareKit.authService,
-              let secrets = await appConfiguration.fetchSecrets(tokenProvider: authService) else {
-            Log(.info, "No secrets available — Discogs fallback disabled")
+        for attempt in 1...maxAttempts {
+            guard let authService = MusicShareKit.authService,
+                  let secrets = await appConfiguration.fetchSecrets(tokenProvider: authService) else {
+                Log(.info, "Secrets fetch attempt \(attempt)/\(maxAttempts) failed")
+
+                guard attempt < maxAttempts else {
+                    Log(.warning, "No secrets available after \(maxAttempts) attempts — Discogs fallback disabled")
+                    return
+                }
+
+                try? await Task.sleep(for: delay)
+                delay *= 3
+                continue
+            }
+
+            if !secrets.discogsApiKey.isEmpty, !secrets.discogsApiSecret.isEmpty {
+                artworkService = .withDiscogsFallback(key: secrets.discogsApiKey, secret: secrets.discogsApiSecret)
+                await artworkService.clearNegativeCache()
+                Log(.info, "Artwork service upgraded with Discogs fallback (attempt \(attempt))")
+            }
             return
-        }
-
-        if !secrets.discogsApiKey.isEmpty, !secrets.discogsApiSecret.isEmpty {
-            artworkService = .withDiscogsFallback(key: secrets.discogsApiKey, secret: secrets.discogsApiSecret)
-            await artworkService.clearNegativeCache()
-            Log(.info, "Artwork service upgraded with Discogs fallback")
         }
     }
 

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
@@ -202,6 +202,12 @@ struct PlaycutDetailView: View {
                   let image = UIImage(data: data) else {
                 return
             }
+
+            // Store in artwork service cache so playlist rows pick it up
+            if let artworkService, let cgImage = image.cgImage {
+                await artworkService.cacheExternalArtwork(cgImage, for: playcut)
+            }
+
             await MainActor.run {
                 withAnimation(.easeInOut(duration: 0.25)) {
                     self.artwork = image

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutRowView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutRowView.swift
@@ -80,6 +80,7 @@ struct ScrollOffsetPreferenceKey: PreferenceKey {
 
 struct PlaycutRowView: View {
     let playcut: Playcut
+    let artworkLoadGeneration: Int
     let onSelect: (UIImage?) -> Void
 
     @State private var artwork: UIImage?
@@ -199,18 +200,22 @@ struct PlaycutRowView: View {
                 let range = shadowOffsetAtBottom - shadowOffsetAtTop
                 shadowYOffset = shadowOffsetAtTop + (normalizedPosition * range)
             }
-            .task {
+            .task(id: artworkLoadGeneration) {
                 await loadArtwork()
             }
     }
 
     private func loadArtwork() async {
+        guard artwork == nil else { return }
+
         guard let artworkService = artworkService else {
             await MainActor.run {
                 isLoadingArtwork = false
             }
             return
         }
+
+        await MainActor.run { isLoadingArtwork = true }
 
         do {
             let cgImage = try await artworkService.fetchArtwork(for: playcut)
@@ -262,6 +267,7 @@ extension View {
             artistName: "Laurel Halo",
             releaseTitle: "Atlas"
         ),
+        artworkLoadGeneration: 0,
         onSelect: { _ in }
     )
     .environment(\.artworkService, MultisourceArtworkService())

--- a/WXYC/iOS/Views/Playlist/PlaylistView.swift
+++ b/WXYC/iOS/Views/Playlist/PlaylistView.swift
@@ -29,6 +29,7 @@ struct PlaylistView: View {
     @Binding var selectedPlaycut: PlaycutSelection?
 
     @State private var playlistEntries: [any PlaylistEntry] = []
+    @State private var artworkLoadGeneration = 0
     @Environment(\.playlistService) private var playlistService
     @Environment(\.isThemePickerActive) private var isThemePickerActive
     @Environment(\.themeAppearance) private var appearance
@@ -150,6 +151,11 @@ struct PlaylistView: View {
                 }
             }
         }
+        .onChange(of: selectedPlaycut != nil) { wasPresented, isPresented in
+            if wasPresented && !isPresented {
+                artworkLoadGeneration &+= 1
+            }
+        }
         .themePickerGesture(
             pickerState: appState.themePickerState,
             configuration: appState.themeConfiguration
@@ -161,7 +167,7 @@ struct PlaylistView: View {
     private func playlistRow(for entry: any PlaylistEntry) -> some View {
         switch entry {
         case let playcut as Playcut:
-            PlaycutRowView(playcut: playcut) { artwork in
+            PlaycutRowView(playcut: playcut, artworkLoadGeneration: artworkLoadGeneration) { artwork in
                 selectedPlaycut = PlaycutSelection(playcut: playcut, artwork: artwork)
             }
 


### PR DESCRIPTION
## Summary

- Check positive artwork cache before negative error cache in `MultisourceArtworkService.scanFetchers`, so externally-stored artwork isn't blocked by stale "not found" entries
- Add `cacheExternalArtwork(_:for:)` to `MultisourceArtworkService` so artwork loaded outside the normal fetcher chain can be stored for playlist rows to find
- Have `PlaycutDetailView` store metadata-fallback artwork in the service cache
- Use `.task(id: artworkLoadGeneration)` in `PlaycutRowView` so rows reload artwork when the detail sheet dismisses
- Add exponential backoff retry to `Singletonia.fetchConfiguration()` so a transient timeout doesn't disable Discogs fallback for the entire session

Closes #207

## Test plan

- [ ] Launch app, verify playlist rows load artwork (not permanent placeholders)
- [ ] Tap a playcut → detail view → go back → verify the row now shows artwork
- [ ] Re-enter the same detail → verify artwork appears immediately (no crossfade, served from cache)
- [ ] Scroll playlist after viewing a detail — other rows should also load artwork on scroll
- [ ] Kill and relaunch app — cached artwork should appear immediately
- [ ] Run Artwork test suite (47 tests, all pass)