### PR TITLE
Fix V2 flowsheet API decoding after response format change

### DIFF
--- a/Shared/Playlist/Sources/Playlist/V2/FlowsheetConverter.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/FlowsheetConverter.swift
@@ -24,7 +24,7 @@ enum FlowsheetConverter {
         var showMarkers: [ShowMarker] = []
 
         for entry in entries {
-            let entryType = FlowsheetEntryType.from(message: entry.message)
+            let entryType = FlowsheetEntryType.from(entry)
             let hour = parseHour(from: entry.add_time)
             let chronOrderID = UInt64(entry.play_order)
             let id = UInt64(entry.id)

--- a/Shared/Playlist/Sources/Playlist/V2/FlowsheetEntry.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/FlowsheetEntry.swift
@@ -10,13 +10,16 @@
 
 import Foundation
 
+/// Wrapper for the v2 flowsheet API response, which nests entries under an `"entries"` key.
+struct FlowsheetResponse: Codable, Sendable {
+    let entries: [FlowsheetEntry]
+}
+
 /// Raw response model for a single entry from the v2 flowsheet API.
 ///
-/// Entry type is determined by the `message` field:
-/// - `nil` = playcut (regular song)
-/// - `"Talkset"` = talkset
-/// - Contains `"Breakpoint"` = breakpoint
-/// - `"Start of Show: ..."` / `"End of Show: ..."` = show marker
+/// Entry type is determined by the `entry_type` field (`"track"`, `"talkset"`,
+/// `"breakpoint"`, `"show_start"`, `"show_end"`). The older `message`-based
+/// detection is used as a fallback when `entry_type` is absent.
 struct FlowsheetEntry: Codable, Sendable {
     let id: Int
     let show_id: Int?
@@ -31,6 +34,13 @@ struct FlowsheetEntry: Codable, Sendable {
     let message: String?
     let play_order: Int
     let add_time: String
+
+    /// Explicit entry type from the v2 API (e.g. `"track"`, `"talkset"`, `"breakpoint"`,
+    /// `"show_start"`, `"show_end"`). `nil` when decoding older response formats.
+    var entry_type: String? = nil
+
+    /// DJ name for show start/end markers. Present only in v2 responses.
+    var dj_name: String? = nil
 
     // Metadata fields from album_metadata/artist_metadata LEFT JOINs.
     // Present only in v2 responses after backend enrichment completes.

--- a/Shared/Playlist/Sources/Playlist/V2/FlowsheetEntryType.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/FlowsheetEntryType.swift
@@ -10,7 +10,8 @@
 
 import Foundation
 
-/// Represents the type of a flowsheet entry, determined by parsing the `message` field.
+/// Represents the type of a flowsheet entry, determined from the `entry_type` field
+/// with a fallback to the legacy `message`-based heuristic.
 enum FlowsheetEntryType: Equatable, Sendable {
     case playcut
     case talkset
@@ -18,7 +19,35 @@ enum FlowsheetEntryType: Equatable, Sendable {
     case showStart(djName: String?)
     case showEnd(djName: String?)
 
-    /// Determines the entry type from the message field.
+    /// Determines the entry type from a flowsheet entry's fields.
+    ///
+    /// Uses `entry_type` (v2 API) as the primary signal. Falls back to the
+    /// legacy `message`-based heuristic when `entry_type` is absent.
+    ///
+    /// - Parameter entry: A raw flowsheet entry.
+    /// - Returns: The detected entry type.
+    static func from(_ entry: FlowsheetEntry) -> FlowsheetEntryType {
+        if let entryType = entry.entry_type {
+            switch entryType {
+            case "track":
+                return .playcut
+            case "talkset":
+                return .talkset
+            case "breakpoint":
+                return .breakpoint
+            case "show_start":
+                return .showStart(djName: entry.dj_name?.nilIfEmpty)
+            case "show_end":
+                return .showEnd(djName: entry.dj_name?.nilIfEmpty)
+            default:
+                return .playcut
+            }
+        }
+
+        return from(message: entry.message)
+    }
+
+    /// Legacy entry type detection from the message field.
     ///
     /// - Parameter message: The message field from a FlowsheetEntry.
     /// - Returns: The detected entry type.
@@ -71,5 +100,11 @@ enum FlowsheetEntryType: Equatable, Sendable {
         }
         // Fallback: return the whole trimmed string
         return trimmed.isEmpty ? nil : trimmed
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        isEmpty ? nil : self
     }
 }

--- a/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
+++ b/Shared/Playlist/Sources/Playlist/V2/PlaylistDataSourceV2.swift
@@ -27,7 +27,7 @@ public final class PlaylistDataSourceV2: PlaylistDataSource, @unchecked Sendable
     public func getPlaylist() async throws -> Playlist {
         let (data, response) = try await session.data(from: URL.WXYCFlowsheet)
         try (response as? HTTPURLResponse)?.validateSuccessStatus()
-        let entries = try JSONDecoder.shared.decode([FlowsheetEntry].self, from: data)
-        return FlowsheetConverter.convert(entries)
+        let flowsheet = try JSONDecoder.shared.decode(FlowsheetResponse.self, from: data)
+        return FlowsheetConverter.convert(flowsheet.entries)
     }
 }

--- a/Shared/Playlist/Tests/PlaylistTests/Fixtures/flowsheet-v2-sample.json
+++ b/Shared/Playlist/Tests/PlaylistTests/Fixtures/flowsheet-v2-sample.json
@@ -1,0 +1,65 @@
+{
+    "entries": [
+        {
+            "id": 5194730,
+            "show_id": 1946226,
+            "play_order": 32,
+            "add_time": "2026-04-17T23:00:47.490Z",
+            "entry_type": "show_end",
+            "dj_name": "DJ Moonbeam",
+            "timestamp": ""
+        },
+        {
+            "id": 5194729,
+            "show_id": 1946226,
+            "play_order": 31,
+            "add_time": "2026-04-17T23:00:45.205Z",
+            "entry_type": "breakpoint",
+            "message": null
+        },
+        {
+            "id": 5194728,
+            "show_id": 1946226,
+            "play_order": 30,
+            "add_time": "2026-04-17T22:53:48.500Z",
+            "entry_type": "track",
+            "album_id": null,
+            "rotation_id": null,
+            "artist_name": "Miyako Koda",
+            "album_title": "in the shadow of Jupiter",
+            "track_title": "Sleep in Peace",
+            "record_label": "Grandisc",
+            "label_id": null,
+            "request_flag": false,
+            "segue": false,
+            "rotation_bin": null,
+            "artwork_url": null,
+            "discogs_url": null,
+            "release_year": null,
+            "spotify_url": null,
+            "apple_music_url": null,
+            "youtube_music_url": null,
+            "bandcamp_url": null,
+            "soundcloud_url": null,
+            "artist_bio": null,
+            "artist_wikipedia_url": null
+        },
+        {
+            "id": 5194724,
+            "show_id": 1946226,
+            "play_order": 28,
+            "add_time": "2026-04-17T22:43:17.263Z",
+            "entry_type": "talkset",
+            "message": null
+        },
+        {
+            "id": 5194720,
+            "show_id": 1946226,
+            "play_order": 1,
+            "add_time": "2026-04-17T20:00:01.000Z",
+            "entry_type": "show_start",
+            "dj_name": "DJ Moonbeam",
+            "timestamp": ""
+        }
+    ]
+}

--- a/Shared/Playlist/Tests/PlaylistTests/FlowsheetConverterTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/FlowsheetConverterTests.swift
@@ -312,4 +312,68 @@ struct FlowsheetConverterTests {
         #expect(playlist.breakpoints.count == 1)
         #expect(playlist.showMarkers.count == 1)
     }
+
+    // MARK: - V2 API response format
+
+    @Test("Decodes and converts V2 API response with entry_type field")
+    func decodesV2ResponseWrapper() throws {
+        let fixtureURL = Bundle.module.url(
+            forResource: "flowsheet-v2-sample",
+            withExtension: "json",
+            subdirectory: "Fixtures"
+        )!
+        let data = try Data(contentsOf: fixtureURL)
+
+        let response = try JSONDecoder().decode(FlowsheetResponse.self, from: data)
+        let playlist = FlowsheetConverter.convert(response.entries)
+
+        #expect(playlist.playcuts.count == 1)
+        #expect(playlist.talksets.count == 1)
+        #expect(playlist.breakpoints.count == 1)
+        #expect(playlist.showMarkers.count == 2)
+
+        let playcut = try #require(playlist.playcuts.first)
+        #expect(playcut.artistName == "Miyako Koda")
+        #expect(playcut.songTitle == "Sleep in Peace")
+        #expect(playcut.releaseTitle == "in the shadow of Jupiter")
+        #expect(playcut.labelName == "Grandisc")
+
+        let showStart = try #require(playlist.showMarkers.first { $0.isStart })
+        #expect(showStart.djName == "DJ Moonbeam")
+
+        let showEnd = try #require(playlist.showMarkers.first { !$0.isStart })
+        #expect(showEnd.djName == "DJ Moonbeam")
+    }
+
+    @Test("Converts V2 talkset with nil message using entry_type")
+    func convertsV2TalksetWithNilMessage() {
+        let entry = FlowsheetEntry(
+            id: 100, show_id: nil, album_id: nil,
+            artist_name: nil, album_title: nil, track_title: nil,
+            record_label: nil, rotation_id: nil, rotation_play_freq: nil,
+            request_flag: nil, message: nil, play_order: 1,
+            add_time: "2026-04-17T22:00:00Z", entry_type: "talkset"
+        )
+
+        let playlist = FlowsheetConverter.convert([entry])
+
+        #expect(playlist.talksets.count == 1)
+        #expect(playlist.playcuts.isEmpty)
+    }
+
+    @Test("Converts V2 breakpoint with nil message using entry_type")
+    func convertsV2BreakpointWithNilMessage() {
+        let entry = FlowsheetEntry(
+            id: 101, show_id: nil, album_id: nil,
+            artist_name: nil, album_title: nil, track_title: nil,
+            record_label: nil, rotation_id: nil, rotation_play_freq: nil,
+            request_flag: nil, message: nil, play_order: 2,
+            add_time: "2026-04-17T22:00:00Z", entry_type: "breakpoint"
+        )
+
+        let playlist = FlowsheetConverter.convert([entry])
+
+        #expect(playlist.breakpoints.count == 1)
+        #expect(playlist.playcuts.isEmpty)
+    }
 }

--- a/Shared/Playlist/Tests/PlaylistTests/FlowsheetEntryTypeTests.swift
+++ b/Shared/Playlist/Tests/PlaylistTests/FlowsheetEntryTypeTests.swift
@@ -110,4 +110,89 @@ struct FlowsheetEntryTypeTests {
         let entryType = FlowsheetEntryType.from(message: "breakpoint")
         #expect(entryType == .playcut)
     }
+
+    // MARK: - entry_type field detection (v2 API)
+
+    @Test("entry_type 'track' returns playcut")
+    func entryTypeTrackIsPlaycut() {
+        let entry = FlowsheetEntry(
+            id: 1, show_id: nil, album_id: nil, artist_name: "Autechre",
+            album_title: "Confield", track_title: "VI Scose Poise",
+            record_label: "Warp", rotation_id: nil, rotation_play_freq: nil,
+            request_flag: false, message: nil, play_order: 1,
+            add_time: "2026-04-17T22:00:00Z", entry_type: "track"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .playcut)
+    }
+
+    @Test("entry_type 'talkset' returns talkset even when message is nil")
+    func entryTypeTalksetWithNilMessage() {
+        let entry = FlowsheetEntry(
+            id: 2, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: nil, play_order: 2, add_time: "2026-04-17T22:05:00Z",
+            entry_type: "talkset"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .talkset)
+    }
+
+    @Test("entry_type 'breakpoint' returns breakpoint even when message is nil")
+    func entryTypeBreakpointWithNilMessage() {
+        let entry = FlowsheetEntry(
+            id: 3, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: nil, play_order: 3, add_time: "2026-04-17T22:10:00Z",
+            entry_type: "breakpoint"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .breakpoint)
+    }
+
+    @Test("entry_type 'show_start' returns showStart with dj_name")
+    func entryTypeShowStart() {
+        let entry = FlowsheetEntry(
+            id: 4, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: nil, play_order: 4, add_time: "2026-04-17T20:00:00Z",
+            entry_type: "show_start", dj_name: "DJ Moonbeam"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .showStart(djName: "DJ Moonbeam"))
+    }
+
+    @Test("entry_type 'show_end' returns showEnd with dj_name")
+    func entryTypeShowEnd() {
+        let entry = FlowsheetEntry(
+            id: 5, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: nil, play_order: 5, add_time: "2026-04-17T23:00:00Z",
+            entry_type: "show_end", dj_name: "DJ Moonbeam"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .showEnd(djName: "DJ Moonbeam"))
+    }
+
+    @Test("entry_type 'show_start' with empty dj_name returns nil djName")
+    func entryTypeShowStartEmptyDJName() {
+        let entry = FlowsheetEntry(
+            id: 6, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: nil, play_order: 6, add_time: "2026-04-17T20:00:00Z",
+            entry_type: "show_start", dj_name: ""
+        )
+        #expect(FlowsheetEntryType.from(entry) == .showStart(djName: nil))
+    }
+
+    @Test("Falls back to message-based detection when entry_type is nil")
+    func fallsBackToMessageDetection() {
+        let entry = FlowsheetEntry(
+            id: 7, show_id: nil, album_id: nil, artist_name: nil,
+            album_title: nil, track_title: nil, record_label: nil,
+            rotation_id: nil, rotation_play_freq: nil, request_flag: nil,
+            message: "Talkset", play_order: 7, add_time: "2026-04-17T22:00:00Z"
+        )
+        #expect(FlowsheetEntryType.from(entry) == .talkset)
+    }
 }


### PR DESCRIPTION
## Summary

- The V2 flowsheet API (`api.wxyc.org/flowsheet`) changed its response format: entries are now wrapped in `{"entries": [...]}` and entry types are conveyed via an explicit `entry_type` field instead of the `message` field (which is now `null` for non-track entries).
- This caused a `typeMismatch` decoding error, resulting in an empty playlist for all users.
- Adds `FlowsheetResponse` wrapper, `entry_type`/`dj_name` fields on `FlowsheetEntry`, and updates `FlowsheetEntryType` to use the new field with a fallback to the legacy `message`-based heuristic.

## Test plan

- [x] All 92 Playlist package tests pass (`swift test` in `Shared/Playlist/`)
- [x] New tests cover: V2 response wrapper decoding, `entry_type`-based detection for all types, `dj_name` extraction for show markers, empty `dj_name` handling, fallback to `message`-based detection
- [ ] Manual verification: launch app and confirm playlist loads with live API data