### PR TITLE
Fix anonymous session persistence with iCloud Keychain fallback

### DIFF
--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
@@ -15,8 +15,10 @@ import Security
 
 /// Keychain-backed token storage for anonymous authentication sessions.
 ///
-/// Stores authentication sessions in the device Keychain. Anonymous session tokens
-/// are device-specific and not synchronized via iCloud Keychain (see issue #210).
+/// Stores authentication sessions in the Keychain with optional iCloud synchronization
+/// for cross-device session persistence. When iCloud Keychain is unavailable (e.g.,
+/// simulators or devices without an iCloud account), saves fall back to local-only
+/// storage to ensure sessions always persist across app launches (see issue #210).
 public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
 
     /// The service name for Keychain items.
@@ -41,10 +43,11 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
     /// - Parameters:
     ///   - accessGroup: The Keychain access group for sharing between targets.
     ///                  Pass `nil` for app-only storage. Format: `$(TeamID).group.name`
-    ///   - synchronizable: Whether to sync via iCloud Keychain. Defaults to `false`.
-    ///                      Anonymous session tokens are device-specific and should not sync.
+    ///   - synchronizable: Whether to sync via iCloud Keychain. Defaults to `true`.
+    ///                      When `true`, saves fall back to non-synchronizable storage if
+    ///                      iCloud Keychain is unavailable (e.g., simulators).
     ///   - analytics: Analytics service for tracking keychain errors.
-    public init(accessGroup: String?, synchronizable: Bool = false, analytics: AnalyticsService) {
+    public init(accessGroup: String?, synchronizable: Bool = true, analytics: AnalyticsService) {
         self.service = "org.wxyc.app.auth"
         self.account = "anonymous-session"
         self.accessGroup = accessGroup
@@ -96,10 +99,12 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
             }
 
         case errSecItemNotFound:
-            // One-time migration: check for items saved with the old synchronizable=true
-            // setting (issue #210). If found, migrate to non-synchronizable storage.
-            if !synchronizable {
-                return migrateFromSynchronizable()
+            // Fallback: when synchronizable=true, baseQuery includes
+            // kSecAttrSynchronizableAny which should match both sync and non-sync
+            // items. But if the query still found nothing, check without the sync
+            // flag in case of edge cases (issue #210).
+            if synchronizable {
+                return loadNonSynchronizable()
             }
             return nil
 
@@ -121,7 +126,7 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
             throw AuthenticationError.keychainError(status: errSecParam)
         }
 
-        // Try to update existing item first
+        // Try to update existing item first (matches both sync and non-sync items)
         var query = baseQuery()
         let attributes: [String: Any] = [
             kSecValueData as String: data
@@ -137,6 +142,14 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
                 query[kSecAttrSynchronizable as String] = true
             }
             status = SecItemAdd(query as CFDictionary, nil)
+
+            // Fall back to non-synchronizable if iCloud Keychain is unavailable
+            // (e.g., simulators, devices without iCloud). Local persistence is
+            // better than no persistence (issue #210).
+            if synchronizable && status != errSecSuccess {
+                query[kSecAttrSynchronizable as String] = false
+                status = SecItemAdd(query as CFDictionary, nil)
+            }
         }
 
         if status != errSecSuccess {
@@ -180,24 +193,18 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
         return query
     }
 
-    /// Attempts to find and migrate a session saved with `kSecAttrSynchronizable = true`.
+    /// Attempts to load a session saved without the synchronizable flag.
     ///
-    /// Prior to issue #210, anonymous session tokens were stored as synchronizable
-    /// Keychain items (iCloud Keychain sync). This caused persistence failures when
-    /// iCloud Keychain was unavailable, creating a new anonymous user on every launch.
+    /// When iCloud Keychain is unavailable (simulators, devices without iCloud),
+    /// `save()` falls back to storing items without `kSecAttrSynchronizable`. This
+    /// method finds those fallback items using a query without the sync attribute.
     ///
-    /// This method searches for any item matching the service/account regardless of
-    /// sync status, and if found, re-saves it as a non-synchronizable item.
-    ///
-    /// - Returns: The migrated session, or `nil` if no synchronizable item was found
-    ///   or migration failed.
-    private func migrateFromSynchronizable() -> AuthSession? {
-        // Build a standalone query (not baseQuery) that finds items regardless of sync status
+    /// - Returns: The session if found, or `nil`.
+    private func loadNonSynchronizable() -> AuthSession? {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: service,
             kSecAttrAccount as String: account,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
             kSecReturnData as String: true,
             kSecMatchLimit as String: kSecMatchLimitOne
         ]
@@ -213,46 +220,12 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
             return nil
         }
 
-        // Decode the session
-        let session: AuthSession
         do {
-            session = try JSONDecoder.shared.decode(AuthSession.self, from: data)
+            return try JSONDecoder.shared.decode(AuthSession.self, from: data)
         } catch {
-            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
+            trackKeychainError(operation: .read, status: errSecDecode)
             return nil
         }
-
-        // Delete the old synchronizable item
-        let deleteQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: service,
-            kSecAttrAccount as String: account,
-            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
-        ]
-        SecItemDelete(deleteQuery as CFDictionary)
-
-        // Re-save as non-synchronizable (lock is already held by load())
-        let newData: Data
-        do {
-            newData = try JSONEncoder().encode(session)
-        } catch {
-            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
-            return nil
-        }
-
-        var addQuery = baseQuery()
-        addQuery[kSecValueData as String] = newData
-        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-
-        if addStatus != errSecSuccess {
-            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
-            // Still return the session — it's valid, just couldn't persist the migration
-            return session
-        }
-
-        analytics.capture(RequestLineKeychainMigratedEvent(success: true))
-        return session
     }
 
     private func trackKeychainError(operation: KeychainOperation, status: OSStatus) {

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/KeychainTokenStorage.swift
@@ -2,7 +2,7 @@
 //  KeychainTokenStorage.swift
 //  MusicShareKit
 //
-//  Keychain-backed token storage with iCloud sync support.
+//  Keychain-backed token storage for anonymous authentication sessions.
 //
 //  Created by Jake Bromberg on 01/20/26.
 //  Copyright © 2026 WXYC. All rights reserved.
@@ -13,17 +13,17 @@ import Core
 import Foundation
 import Security
 
-/// Keychain-backed token storage with iCloud sync support.
+/// Keychain-backed token storage for anonymous authentication sessions.
 ///
-/// Stores authentication sessions in the Keychain with optional iCloud synchronization
-/// for seamless device-to-device session sharing.
+/// Stores authentication sessions in the device Keychain. Anonymous session tokens
+/// are device-specific and not synchronized via iCloud Keychain (see issue #210).
 public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
 
     /// The service name for Keychain items.
-    private static let service = "org.wxyc.app.auth"
+    private let service: String
 
     /// The account name for the anonymous session.
-    private static let account = "anonymous-session"
+    private let account: String
 
     /// The Keychain access group for sharing between app and extensions.
     private let accessGroup: String?
@@ -41,9 +41,28 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
     /// - Parameters:
     ///   - accessGroup: The Keychain access group for sharing between targets.
     ///                  Pass `nil` for app-only storage. Format: `$(TeamID).group.name`
-    ///   - synchronizable: Whether to sync via iCloud Keychain. Defaults to `true`.
+    ///   - synchronizable: Whether to sync via iCloud Keychain. Defaults to `false`.
+    ///                      Anonymous session tokens are device-specific and should not sync.
     ///   - analytics: Analytics service for tracking keychain errors.
-    public init(accessGroup: String?, synchronizable: Bool = true, analytics: AnalyticsService) {
+    public init(accessGroup: String?, synchronizable: Bool = false, analytics: AnalyticsService) {
+        self.service = "org.wxyc.app.auth"
+        self.account = "anonymous-session"
+        self.accessGroup = accessGroup
+        self.synchronizable = synchronizable
+        self.analytics = analytics
+    }
+
+    /// Creates a Keychain token storage with custom service and account names.
+    /// Used for testing with isolated Keychain items.
+    init(
+        service: String,
+        account: String,
+        accessGroup: String?,
+        synchronizable: Bool,
+        analytics: AnalyticsService
+    ) {
+        self.service = service
+        self.account = account
         self.accessGroup = accessGroup
         self.synchronizable = synchronizable
         self.analytics = analytics
@@ -77,6 +96,11 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
             }
 
         case errSecItemNotFound:
+            // One-time migration: check for items saved with the old synchronizable=true
+            // setting (issue #210). If found, migrate to non-synchronizable storage.
+            if !synchronizable {
+                return migrateFromSynchronizable()
+            }
             return nil
 
         default:
@@ -140,8 +164,8 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
     private func baseQuery() -> [String: Any] {
         var query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: Self.service,
-            kSecAttrAccount as String: Self.account
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account
         ]
 
         if let accessGroup {
@@ -154,6 +178,81 @@ public final class KeychainTokenStorage: TokenStorage, @unchecked Sendable {
         }
 
         return query
+    }
+
+    /// Attempts to find and migrate a session saved with `kSecAttrSynchronizable = true`.
+    ///
+    /// Prior to issue #210, anonymous session tokens were stored as synchronizable
+    /// Keychain items (iCloud Keychain sync). This caused persistence failures when
+    /// iCloud Keychain was unavailable, creating a new anonymous user on every launch.
+    ///
+    /// This method searches for any item matching the service/account regardless of
+    /// sync status, and if found, re-saves it as a non-synchronizable item.
+    ///
+    /// - Returns: The migrated session, or `nil` if no synchronizable item was found
+    ///   or migration failed.
+    private func migrateFromSynchronizable() -> AuthSession? {
+        // Build a standalone query (not baseQuery) that finds items regardless of sync status
+        var query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny,
+            kSecReturnData as String: true,
+            kSecMatchLimit as String: kSecMatchLimitOne
+        ]
+
+        if let accessGroup {
+            query[kSecAttrAccessGroup as String] = accessGroup
+        }
+
+        var result: AnyObject?
+        let status = SecItemCopyMatching(query as CFDictionary, &result)
+
+        guard status == errSecSuccess, let data = result as? Data else {
+            return nil
+        }
+
+        // Decode the session
+        let session: AuthSession
+        do {
+            session = try JSONDecoder.shared.decode(AuthSession.self, from: data)
+        } catch {
+            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
+            return nil
+        }
+
+        // Delete the old synchronizable item
+        let deleteQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
+        ]
+        SecItemDelete(deleteQuery as CFDictionary)
+
+        // Re-save as non-synchronizable (lock is already held by load())
+        let newData: Data
+        do {
+            newData = try JSONEncoder().encode(session)
+        } catch {
+            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
+            return nil
+        }
+
+        var addQuery = baseQuery()
+        addQuery[kSecValueData as String] = newData
+        addQuery[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlock
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+
+        if addStatus != errSecSuccess {
+            analytics.capture(RequestLineKeychainMigratedEvent(success: false))
+            // Still return the session — it's valid, just couldn't persist the migration
+            return session
+        }
+
+        analytics.capture(RequestLineKeychainMigratedEvent(success: true))
+        return session
     }
 
     private func trackKeychainError(operation: KeychainOperation, status: OSStatus) {

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
@@ -162,6 +162,22 @@ public struct RequestLineKeychainErrorEvent: RequestLineAnalyticsEvent {
     }
 }
 
+/// Event captured when a Keychain item is migrated from synchronizable to non-synchronizable.
+///
+/// This one-time migration occurs on the first launch after the app stops using iCloud Keychain
+/// sync for anonymous session tokens (issue #210).
+public struct RequestLineKeychainMigratedEvent: RequestLineAnalyticsEvent {
+    public let success: Bool
+
+    public var properties: [String: Any]? {
+        ["success": success]
+    }
+
+    public init(success: Bool) {
+        self.success = success
+    }
+}
+
 // MARK: - Ban Events
 
 /// Event captured when a user is banned.

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
@@ -162,22 +162,6 @@ public struct RequestLineKeychainErrorEvent: RequestLineAnalyticsEvent {
     }
 }
 
-/// Event captured when a Keychain item is migrated from synchronizable to non-synchronizable.
-///
-/// This one-time migration occurs on the first launch after the app stops using iCloud Keychain
-/// sync for anonymous session tokens (issue #210).
-public struct RequestLineKeychainMigratedEvent: RequestLineAnalyticsEvent {
-    public let success: Bool
-
-    public var properties: [String: Any]? {
-        ["success": success]
-    }
-
-    public init(success: Bool) {
-        self.success = success
-    }
-}
-
 // MARK: - Ban Events
 
 /// Event captured when a user is banned.

--- a/Shared/MusicShareKit/Sources/MusicShareKit/MusicShareKitConfiguration.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/MusicShareKitConfiguration.swift
@@ -83,7 +83,6 @@ public enum MusicShareKit {
         if let authBaseURL = configuration.authBaseURL {
             let storage = KeychainTokenStorage(
                 accessGroup: configuration.keychainAccessGroup,
-                synchronizable: true,
                 analytics: configuration.analyticsService
             )
             _authService = AuthenticationService(

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/KeychainTokenStorageTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/KeychainTokenStorageTests.swift
@@ -1,0 +1,175 @@
+//
+//  KeychainTokenStorageTests.swift
+//  MusicShareKit
+//
+//  Integration tests for KeychainTokenStorage using the real Keychain on simulator.
+//  Verifies round-trip persistence and migration from synchronizable items.
+//
+//  Created by Jake Bromberg on 04/21/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import AnalyticsTesting
+import Foundation
+import Security
+import Testing
+@testable import MusicShareKit
+
+// MARK: - Keychain Constants (mirrors KeychainTokenStorage private statics)
+
+private let testService = "org.wxyc.app.auth.test"
+private let testAccount = "anonymous-session-test"
+
+@Suite("KeychainTokenStorage Tests", .serialized)
+struct KeychainTokenStorageTests {
+
+    let mockAnalytics = MockStructuredAnalytics()
+
+    init() {
+        // Clean up any leftover items from prior test runs
+        deleteAllTestKeychainItems()
+    }
+
+    // MARK: - Round-Trip Persistence
+
+    @Test("Save and load round-trips session across instances")
+    func saveAndLoadRoundTripsAcrossInstances() throws {
+        let session = AuthSession(
+            token: "persist-token-abc",
+            userId: "persist-user-123",
+            createdAt: Date(),
+            expiresAt: nil
+        )
+
+        // Save with first instance
+        let storage1 = makeStorage(synchronizable: false)
+        try storage1.save(session)
+
+        // Load with a fresh instance (simulates app relaunch)
+        let storage2 = makeStorage(synchronizable: false)
+        let loaded = try storage2.load()
+
+        #expect(loaded?.token == session.token)
+        #expect(loaded?.userId == session.userId)
+
+        // Clean up
+        try storage2.delete()
+    }
+
+    // MARK: - Migration from Synchronizable Items
+
+    @Test("Migrates synchronizable item to non-synchronizable on load")
+    func migratesSynchronizableItem() throws {
+        let session = AuthSession(
+            token: "sync-token-xyz",
+            userId: "sync-user-456",
+            createdAt: Date(),
+            expiresAt: nil
+        )
+
+        // Save directly to keychain with kSecAttrSynchronizable = true (old behavior).
+        // Synchronizable items require entitlements only available on iOS simulator,
+        // so skip this test on macOS where swift test runs.
+        let data = try JSONEncoder().encode(session)
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount,
+            kSecAttrSynchronizable as String: true,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecValueData as String: data
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else {
+            // -34018 (errSecMissingEntitlement) on macOS; test requires iOS simulator
+            return
+        }
+
+        // Load with non-synchronizable storage — should migrate and return the session
+        let storage = makeStorage(synchronizable: false)
+        let loaded = try storage.load()
+
+        #expect(loaded?.token == session.token)
+        #expect(loaded?.userId == session.userId)
+
+        // Verify the old synchronizable item is gone
+        let syncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount,
+            kSecAttrSynchronizable as String: true
+        ]
+        let syncStatus = SecItemCopyMatching(syncQuery as CFDictionary, nil)
+        #expect(syncStatus == errSecItemNotFound, "Old synchronizable item should have been deleted")
+
+        // Verify the new non-synchronizable item exists
+        let nonSyncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount,
+            kSecReturnData as String: true
+        ]
+        var result: AnyObject?
+        let nonSyncStatus = SecItemCopyMatching(nonSyncQuery as CFDictionary, &result)
+        #expect(nonSyncStatus == errSecSuccess, "New non-synchronizable item should exist")
+
+        // Clean up
+        try storage.delete()
+    }
+
+    @Test("Migration tracks analytics event")
+    func migrationTracksAnalytics() throws {
+        let session = AuthSession(
+            token: "analytics-token",
+            userId: "analytics-user",
+            createdAt: Date(),
+            expiresAt: nil
+        )
+
+        // Seed a synchronizable item (skip on macOS — see migratesSynchronizableItem)
+        let data = try JSONEncoder().encode(session)
+        let addQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount,
+            kSecAttrSynchronizable as String: true,
+            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
+            kSecValueData as String: data
+        ]
+        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
+        guard addStatus == errSecSuccess else { return }
+
+        mockAnalytics.reset()
+        let storage = makeStorage(synchronizable: false)
+        _ = try storage.load()
+
+        let eventNames = mockAnalytics.capturedEventNames()
+        #expect(eventNames.contains("request_line_keychain_migrated_event"))
+
+        // Clean up
+        try storage.delete()
+    }
+
+    // MARK: - Helpers
+
+    private func makeStorage(synchronizable: Bool) -> KeychainTokenStorage {
+        KeychainTokenStorage(
+            service: testService,
+            account: testAccount,
+            accessGroup: nil,
+            synchronizable: synchronizable,
+            analytics: mockAnalytics
+        )
+    }
+
+    private func deleteAllTestKeychainItems() {
+        // Delete both synchronizable and non-synchronizable items
+        let query: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount,
+            kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
+        ]
+        SecItemDelete(query as CFDictionary)
+    }
+}

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/KeychainTokenStorageTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/KeychainTokenStorageTests.swift
@@ -2,8 +2,8 @@
 //  KeychainTokenStorageTests.swift
 //  MusicShareKit
 //
-//  Integration tests for KeychainTokenStorage using the real Keychain on simulator.
-//  Verifies round-trip persistence and migration from synchronizable items.
+//  Integration tests for KeychainTokenStorage using the real Keychain.
+//  Verifies round-trip persistence, synchronizable fallback, and load fallback.
 //
 //  Created by Jake Bromberg on 04/21/26.
 //  Copyright © 2026 WXYC. All rights reserved.
@@ -14,8 +14,6 @@ import Foundation
 import Security
 import Testing
 @testable import MusicShareKit
-
-// MARK: - Keychain Constants (mirrors KeychainTokenStorage private statics)
 
 private let testService = "org.wxyc.app.auth.test"
 private let testAccount = "anonymous-session-test"
@@ -41,7 +39,6 @@ struct KeychainTokenStorageTests {
             expiresAt: nil
         )
 
-        // Save with first instance
         let storage1 = makeStorage(synchronizable: false)
         try storage1.save(session)
 
@@ -52,101 +49,86 @@ struct KeychainTokenStorageTests {
         #expect(loaded?.token == session.token)
         #expect(loaded?.userId == session.userId)
 
-        // Clean up
         try storage2.delete()
     }
 
-    // MARK: - Migration from Synchronizable Items
+    // MARK: - Synchronizable Save Fallback
 
-    @Test("Migrates synchronizable item to non-synchronizable on load")
-    func migratesSynchronizableItem() throws {
+    @Test("Save falls back to non-synchronizable when iCloud Keychain is unavailable")
+    func saveFallsBackToNonSynchronizable() throws {
         let session = AuthSession(
-            token: "sync-token-xyz",
-            userId: "sync-user-456",
+            token: "fallback-token-xyz",
+            userId: "fallback-user-456",
             createdAt: Date(),
             expiresAt: nil
         )
 
-        // Save directly to keychain with kSecAttrSynchronizable = true (old behavior).
-        // Synchronizable items require entitlements only available on iOS simulator,
-        // so skip this test on macOS where swift test runs.
+        // Save with synchronizable=true. On macOS (swift test), iCloud Keychain
+        // is unavailable, so the sync save fails and falls back to non-sync.
+        let storage = makeStorage(synchronizable: true)
+        try storage.save(session)
+
+        // Load should find the item regardless of how it was saved
+        let loaded = try storage.load()
+        #expect(loaded?.token == session.token)
+        #expect(loaded?.userId == session.userId)
+
+        try storage.delete()
+    }
+
+    @Test("Save fallback persists across instances")
+    func saveFallbackPersistsAcrossInstances() throws {
+        let session = AuthSession(
+            token: "relaunch-token",
+            userId: "relaunch-user",
+            createdAt: Date(),
+            expiresAt: nil
+        )
+
+        // Save with synchronizable=true (may fall back to non-sync)
+        let storage1 = makeStorage(synchronizable: true)
+        try storage1.save(session)
+
+        // Load with a fresh synchronizable=true instance (simulates app relaunch)
+        let storage2 = makeStorage(synchronizable: true)
+        let loaded = try storage2.load()
+
+        #expect(loaded?.token == session.token)
+        #expect(loaded?.userId == session.userId)
+
+        try storage2.delete()
+    }
+
+    // MARK: - Load Fallback
+
+    @Test("Load with synchronizable=true finds non-synchronizable items")
+    func loadFindsFallbackItems() throws {
+        let session = AuthSession(
+            token: "nonsync-token",
+            userId: "nonsync-user",
+            createdAt: Date(),
+            expiresAt: nil
+        )
+
+        // Save directly as non-synchronizable (simulates a fallback save)
         let data = try JSONEncoder().encode(session)
         let addQuery: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: testService,
             kSecAttrAccount as String: testAccount,
-            kSecAttrSynchronizable as String: true,
             kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
             kSecValueData as String: data
         ]
         let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        guard addStatus == errSecSuccess else {
-            // -34018 (errSecMissingEntitlement) on macOS; test requires iOS simulator
-            return
-        }
+        #expect(addStatus == errSecSuccess)
 
-        // Load with non-synchronizable storage — should migrate and return the session
-        let storage = makeStorage(synchronizable: false)
+        // Load with synchronizable=true should still find the non-sync item
+        let storage = makeStorage(synchronizable: true)
         let loaded = try storage.load()
 
         #expect(loaded?.token == session.token)
         #expect(loaded?.userId == session.userId)
 
-        // Verify the old synchronizable item is gone
-        let syncQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: testService,
-            kSecAttrAccount as String: testAccount,
-            kSecAttrSynchronizable as String: true
-        ]
-        let syncStatus = SecItemCopyMatching(syncQuery as CFDictionary, nil)
-        #expect(syncStatus == errSecItemNotFound, "Old synchronizable item should have been deleted")
-
-        // Verify the new non-synchronizable item exists
-        let nonSyncQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: testService,
-            kSecAttrAccount as String: testAccount,
-            kSecReturnData as String: true
-        ]
-        var result: AnyObject?
-        let nonSyncStatus = SecItemCopyMatching(nonSyncQuery as CFDictionary, &result)
-        #expect(nonSyncStatus == errSecSuccess, "New non-synchronizable item should exist")
-
-        // Clean up
-        try storage.delete()
-    }
-
-    @Test("Migration tracks analytics event")
-    func migrationTracksAnalytics() throws {
-        let session = AuthSession(
-            token: "analytics-token",
-            userId: "analytics-user",
-            createdAt: Date(),
-            expiresAt: nil
-        )
-
-        // Seed a synchronizable item (skip on macOS — see migratesSynchronizableItem)
-        let data = try JSONEncoder().encode(session)
-        let addQuery: [String: Any] = [
-            kSecClass as String: kSecClassGenericPassword,
-            kSecAttrService as String: testService,
-            kSecAttrAccount as String: testAccount,
-            kSecAttrSynchronizable as String: true,
-            kSecAttrAccessible as String: kSecAttrAccessibleAfterFirstUnlock,
-            kSecValueData as String: data
-        ]
-        let addStatus = SecItemAdd(addQuery as CFDictionary, nil)
-        guard addStatus == errSecSuccess else { return }
-
-        mockAnalytics.reset()
-        let storage = makeStorage(synchronizable: false)
-        _ = try storage.load()
-
-        let eventNames = mockAnalytics.capturedEventNames()
-        #expect(eventNames.contains("request_line_keychain_migrated_event"))
-
-        // Clean up
         try storage.delete()
     }
 
@@ -163,7 +145,6 @@ struct KeychainTokenStorageTests {
     }
 
     private func deleteAllTestKeychainItems() {
-        // Delete both synchronizable and non-synchronizable items
         let query: [String: Any] = [
             kSecClass as String: kSecClassGenericPassword,
             kSecAttrService as String: testService,
@@ -171,5 +152,14 @@ struct KeychainTokenStorageTests {
             kSecAttrSynchronizable as String: kSecAttrSynchronizableAny
         ]
         SecItemDelete(query as CFDictionary)
+
+        // Also delete non-synchronizable items (queries without kSecAttrSynchronizable
+        // won't match synchronizable items and vice versa)
+        let nonSyncQuery: [String: Any] = [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: testService,
+            kSecAttrAccount as String: testAccount
+        ]
+        SecItemDelete(nonSyncQuery as CFDictionary)
     }
 }


### PR DESCRIPTION
## Summary

- When `KeychainTokenStorage.save()` fails to store a synchronizable item (iCloud Keychain unavailable), it now falls back to saving as a non-synchronizable item so the session always persists locally
- When `KeychainTokenStorage.load()` finds nothing with the sync-aware query, it tries a second query without the sync attribute to find fallback items
- Added internal init with custom service/account for test isolation

## Context

The app was creating a new anonymous user via `POST /auth/sign-in/anonymous` on every launch in environments where iCloud Keychain is unavailable (simulators, devices without an iCloud account). `SecItemAdd` with `kSecAttrSynchronizable=true` would fail, the error was caught and logged but the session wasn't persisted, and `ensureAuthenticated()` would fall through to `signInAnonymously()` each time. This produced 147 orphaned anonymous users from a single tester and inflated the admin roster response to 69K.

iCloud Keychain sync is kept enabled for cross-device session persistence on real devices. The fallback ensures local persistence always works.

## Test plan

- [x] Round-trip persistence test verifies save/load across storage instances
- [x] Save fallback test verifies `synchronizable=true` persists even when iCloud is unavailable (runs on macOS where sync items fail)
- [x] Save fallback persists across instances (simulates app relaunch)
- [x] Load fallback test verifies `synchronizable=true` storage finds non-synchronizable items
- [x] All 66 MusicShareKit tests pass
- [ ] After shipping: verify `request_line_auth_completed_event` with `source: keychain` on subsequent launches in PostHog

Closes #210