### PR TITLE
Switch anonymous auth from session tokens to JWTs

### DIFF
--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthNetworkClient.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthNetworkClient.swift
@@ -22,6 +22,15 @@ public protocol AuthNetworkClient: Sendable {
     /// - Returns: A new authentication session.
     /// - Throws: `AuthenticationError` if the sign-in fails.
     func signInAnonymously(baseURL: String) async throws -> AuthSession
+
+    /// Exchanges a session token for a JWT.
+    ///
+    /// - Parameters:
+    ///   - baseURL: The base URL for the authentication API.
+    ///   - sessionToken: The session token from anonymous sign-in.
+    /// - Returns: A JWT string.
+    /// - Throws: `AuthenticationError` if the exchange fails.
+    func fetchJWT(baseURL: String, sessionToken: String) async throws -> String
 }
 
 // MARK: - Default Implementation
@@ -75,9 +84,43 @@ public struct DefaultAuthNetworkClient: AuthNetworkClient {
             throw AuthenticationError.invalidResponse
         }
     }
+
+    public func fetchJWT(baseURL: String, sessionToken: String) async throws -> String {
+        guard let url = URL(string: "\(baseURL)/auth/token") else {
+            throw AuthenticationError.notConfigured
+        }
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        request.addValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.addValue(baseURL, forHTTPHeaderField: "Origin")
+        request.addValue("Bearer \(sessionToken)", forHTTPHeaderField: "Authorization")
+
+        let response: (data: Data, response: URLResponse)
+        do {
+            response = try await session.data(for: request)
+        } catch {
+            throw AuthenticationError.networkError(error)
+        }
+
+        guard let httpResponse = response.response as? HTTPURLResponse else {
+            throw AuthenticationError.invalidResponse
+        }
+
+        guard httpResponse.statusCode == 200 else {
+            throw AuthenticationError.serverError(statusCode: httpResponse.statusCode)
+        }
+
+        do {
+            let tokenResponse = try JSONDecoder.shared.decode(JWTTokenResponse.self, from: response.data)
+            return tokenResponse.token
+        } catch {
+            throw AuthenticationError.invalidResponse
+        }
+    }
 }
 
-// MARK: - Response Model
+// MARK: - Response Models
 
 /// Response from the anonymous sign-in endpoint.
 private struct AuthResponse: Decodable {
@@ -87,6 +130,11 @@ private struct AuthResponse: Decodable {
     struct AuthResponseUser: Decodable {
         let id: String
     }
+}
+
+/// Response from the JWT token exchange endpoint.
+private struct JWTTokenResponse: Decodable {
+    let token: String
 }
 
 // MARK: - Mock Implementation
@@ -100,8 +148,17 @@ public final class MockAuthNetworkClient: AuthNetworkClient, @unchecked Sendable
     /// The error to throw from sign-in.
     public var mockError: Error?
 
+    /// The JWT to return from token exchange, or `nil` to throw an error.
+    public var mockJWT: String?
+
+    /// The error to throw from JWT exchange.
+    public var mockJWTError: Error?
+
     /// The number of times sign-in was called.
     public private(set) var signInCallCount = 0
+
+    /// The number of times JWT exchange was called.
+    public private(set) var fetchJWTCallCount = 0
 
     private let lock = NSLock()
 
@@ -121,12 +178,29 @@ public final class MockAuthNetworkClient: AuthNetworkClient, @unchecked Sendable
         throw AuthenticationError.networkError(URLError(.notConnectedToInternet))
     }
 
+    public func fetchJWT(baseURL: String, sessionToken: String) async throws -> String {
+        lock.withLock { fetchJWTCallCount += 1 }
+
+        if let error = mockJWTError {
+            throw error
+        }
+
+        if let jwt = mockJWT {
+            return jwt
+        }
+
+        throw AuthenticationError.networkError(URLError(.notConnectedToInternet))
+    }
+
     /// Resets all mock state.
     public func reset() {
         lock.lock()
         defer { lock.unlock() }
         mockSession = nil
         mockError = nil
+        mockJWT = nil
+        mockJWTError = nil
         signInCallCount = 0
+        fetchJWTCallCount = 0
     }
 }

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthenticationService.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/AuthenticationService.swift
@@ -53,14 +53,14 @@ public actor AuthenticationService: SessionTokenProvider {
 
     // MARK: - Public API
 
-    /// Ensures the user is authenticated and returns a valid token.
+    /// Ensures the user is authenticated and returns a valid JWT.
     ///
     /// Flow:
-    /// 1. Return cached token if available and not expired
+    /// 1. Return cached JWT if available and not expired
     /// 2. Load from Keychain if not in cache
-    /// 3. Sign in anonymously if no stored session
+    /// 3. Sign in anonymously, exchange session token for JWT
     ///
-    /// - Returns: A valid bearer token.
+    /// - Returns: A valid JWT bearer token.
     /// - Throws: `AuthenticationError` if authentication fails.
     public func ensureAuthenticated() async throws -> String {
         let startTime = CFAbsoluteTimeGetCurrent()
@@ -90,10 +90,10 @@ public actor AuthenticationService: SessionTokenProvider {
 
         trackAuthStarted(source: .network)
 
-        // 3. Sign in anonymously
-        let session: AuthSession
+        // 3. Sign in anonymously to get a session token
+        let signInSession: AuthSession
         do {
-            session = try await networkClient.signInAnonymously(baseURL: baseURL)
+            signInSession = try await networkClient.signInAnonymously(baseURL: baseURL)
         } catch {
             analytics.capture(RequestLineAuthFailedEvent(
                 error: error.localizedDescription,
@@ -101,6 +101,32 @@ public actor AuthenticationService: SessionTokenProvider {
             ))
             throw error
         }
+
+        // 4. Exchange session token for JWT
+        let jwtStartTime = CFAbsoluteTimeGetCurrent()
+        let jwt: String
+        do {
+            jwt = try await networkClient.fetchJWT(baseURL: baseURL, sessionToken: signInSession.token)
+        } catch {
+            analytics.capture(RequestLineAuthFailedEvent(
+                error: error.localizedDescription,
+                phase: .jwtExchange
+            ))
+            throw error
+        }
+        let jwtDuration = (CFAbsoluteTimeGetCurrent() - jwtStartTime) * 1000
+        analytics.capture(RequestLineJWTExchangeEvent(success: true, durationMs: jwtDuration))
+
+        // 5. Decode JWT to extract expiration
+        let payload = try JWTPayloadDecoder.decode(jwt)
+
+        // 6. Build session with JWT as the bearer token
+        let session = AuthSession(
+            token: jwt,
+            userId: signInSession.userId,
+            createdAt: Date(),
+            expiresAt: payload.expiresAt
+        )
 
         // Save to Keychain
         do {

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/JWTPayloadDecoder.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/JWTPayloadDecoder.swift
@@ -1,0 +1,68 @@
+//
+//  JWTPayloadDecoder.swift
+//  MusicShareKit
+//
+//  Minimal JWT payload decoder that extracts the exp claim from a JWT string.
+//  Does not verify signatures — that is the server's responsibility.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Decodes a JWT payload to extract the expiration claim.
+///
+/// JWTs are three base64url-encoded segments separated by dots: `header.payload.signature`.
+/// This decoder only reads the payload segment to extract the `exp` claim.
+enum JWTPayloadDecoder {
+
+    /// The decoded payload containing the expiration date.
+    struct Payload {
+        /// When the JWT expires, derived from the `exp` claim.
+        let expiresAt: Date
+    }
+
+    /// Decodes a JWT string and extracts the expiration claim.
+    ///
+    /// - Parameter jwt: A JWT string in the format `header.payload.signature`.
+    /// - Returns: The decoded payload.
+    /// - Throws: `AuthenticationError.invalidResponse` if the JWT is malformed
+    ///   or missing the `exp` claim.
+    static func decode(_ jwt: String) throws -> Payload {
+        let segments = jwt.split(separator: ".", omittingEmptySubsequences: false)
+        guard segments.count == 3 else {
+            throw AuthenticationError.invalidResponse
+        }
+
+        let payloadSegment = String(segments[1])
+        guard let data = base64urlDecode(payloadSegment) else {
+            throw AuthenticationError.invalidResponse
+        }
+
+        guard let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let exp = json["exp"] as? TimeInterval else {
+            throw AuthenticationError.invalidResponse
+        }
+
+        return Payload(expiresAt: Date(timeIntervalSince1970: exp))
+    }
+
+    /// Decodes a base64url-encoded string to `Data`.
+    ///
+    /// Normalizes URL-safe characters (`-` → `+`, `_` → `/`) and adds
+    /// padding (`=`) as needed for standard base64 decoding.
+    private static func base64urlDecode(_ string: String) -> Data? {
+        var base64 = string
+            .replacingOccurrences(of: "-", with: "+")
+            .replacingOccurrences(of: "_", with: "/")
+
+        // Pad to a multiple of 4
+        let remainder = base64.count % 4
+        if remainder > 0 {
+            base64.append(String(repeating: "=", count: 4 - remainder))
+        }
+
+        return Data(base64Encoded: base64)
+    }
+}

--- a/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
+++ b/Shared/MusicShareKit/Sources/MusicShareKit/Auth/RequestLineAnalytics.swift
@@ -66,6 +66,7 @@ public enum AuthFailurePhase: String, Sendable {
     case keychain
     case network
     case parse
+    case jwtExchange
 }
 
 /// Event captured when authentication fails.
@@ -83,6 +84,24 @@ public struct RequestLineAuthFailedEvent: RequestLineAnalyticsEvent {
     public init(error: String, phase: AuthFailurePhase) {
         self.error = error
         self.phase = phase
+    }
+}
+
+/// Event captured when a JWT exchange completes.
+public struct RequestLineJWTExchangeEvent: RequestLineAnalyticsEvent {
+    public let success: Bool
+    public let durationMs: Double
+
+    public var properties: [String: Any]? {
+        [
+            "success": success,
+            "duration_ms": durationMs
+        ]
+    }
+
+    public init(success: Bool, durationMs: Double) {
+        self.success = success
+        self.durationMs = durationMs
     }
 }
 

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthNetworkClientE2ETests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthNetworkClientE2ETests.swift
@@ -67,6 +67,42 @@ struct AuthNetworkClientE2ETests {
 
         #expect(httpResponse.statusCode == 200)
     }
+
+    // MARK: - JWT Exchange Tests
+
+    @Test("JWT exchange returns a valid JWT with three segments")
+    func jwtExchangeReturnsValidJWT() async throws {
+        let client = makeClient()
+        let session = try await client.signInAnonymously(baseURL: baseURL)
+
+        let jwt = try await client.fetchJWT(baseURL: baseURL, sessionToken: session.token)
+
+        let segments = jwt.split(separator: ".")
+        #expect(segments.count == 3)
+
+        // Verify the JWT payload can be decoded with an exp claim
+        let payload = try JWTPayloadDecoder.decode(jwt)
+        #expect(payload.expiresAt > Date())
+    }
+
+    @Test("JWT from exchange authenticates against /config/secrets",
+          .disabled("Requires WXYC/Backend-Service#376 (JWT-only verification)"))
+    func jwtAuthenticatesAgainstSecrets() async throws {
+        let client = makeClient()
+        let session = try await client.signInAnonymously(baseURL: baseURL)
+        let jwt = try await client.fetchJWT(baseURL: baseURL, sessionToken: session.token)
+
+        var request = URLRequest(url: URL(string: "\(baseURL)/config/secrets")!)
+        request.setValue("Bearer \(jwt)", forHTTPHeaderField: "Authorization")
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let httpResponse = try #require(response as? HTTPURLResponse)
+
+        #expect(httpResponse.statusCode == 200)
+
+        let secrets = try JSONDecoder().decode(SecretsResponse.self, from: data)
+        #expect(!secrets.discogsApiKey.isEmpty)
+    }
 }
 
 /// Minimal decode type for /config/secrets response

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthenticationServiceTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthenticationServiceTests.swift
@@ -51,6 +51,14 @@ struct AuthenticationServiceTests {
         )
     }
 
+    /// Creates a mock network client configured for the two-step auth flow.
+    func makeNetworkClient(session: AuthSession, jwtExpiresIn: TimeInterval = 3600) -> MockAuthNetworkClient {
+        let client = MockAuthNetworkClient()
+        client.mockSession = session
+        client.mockJWT = makeTestJWT(expiresIn: jwtExpiresIn)
+        return client
+    }
+
     // MARK: - ensureAuthenticated Tests
 
     @Test("Returns cached token when available and not expired")
@@ -89,42 +97,47 @@ struct AuthenticationServiceTests {
         #expect(networkClient.signInCallCount == 0)
     }
 
-    @Test("Signs in anonymously when no stored session")
+    @Test("Signs in and exchanges for JWT when no stored session")
     func signsInWhenNoStoredSession() async throws {
         let storage = InMemoryTokenStorage()
-        let networkClient = MockAuthNetworkClient()
-        let session = makeValidSession()
-        networkClient.mockSession = session
+        let signInSession = makeValidSession()
+        let networkClient = makeNetworkClient(session: signInSession)
 
         let service = makeService(storage: storage, networkClient: networkClient)
         let token = try await service.ensureAuthenticated()
 
-        #expect(token == session.token)
+        // Returned token should be the JWT, not the session token
+        #expect(token != signInSession.token)
+        #expect(token.contains("."))
         #expect(networkClient.signInCallCount == 1)
+        #expect(networkClient.fetchJWTCallCount == 1)
 
-        // Verify session was saved to storage
+        // Verify stored session has the JWT and a non-nil expiration
         let storedSession = try storage.load()
-        #expect(storedSession?.token == session.token)
+        #expect(storedSession?.token == token)
+        #expect(storedSession?.expiresAt != nil)
     }
 
     @Test("Signs in when stored session is expired")
     func signsInWhenSessionExpired() async throws {
         let storage = InMemoryTokenStorage()
-        let networkClient = MockAuthNetworkClient()
 
         // Store an expired session
         let expiredSession = makeExpiredSession()
         try storage.save(expiredSession)
 
-        // Network will return a fresh session
+        // Network will return a fresh session + JWT
         let freshSession = makeValidSession()
-        networkClient.mockSession = freshSession
+        let networkClient = makeNetworkClient(session: freshSession)
 
         let service = makeService(storage: storage, networkClient: networkClient)
         let token = try await service.ensureAuthenticated()
 
-        #expect(token == freshSession.token)
+        // Should be the JWT, not the sign-in session token
+        #expect(token != freshSession.token)
+        #expect(token.contains("."))
         #expect(networkClient.signInCallCount == 1)
+        #expect(networkClient.fetchJWTCallCount == 1)
     }
 
     @Test("Throws error when network sign-in fails")
@@ -140,20 +153,83 @@ struct AuthenticationServiceTests {
         }
     }
 
+    @Test("Throws error when JWT exchange fails")
+    func throwsOnJWTExchangeFailure() async throws {
+        let storage = InMemoryTokenStorage()
+        let networkClient = MockAuthNetworkClient()
+        networkClient.mockSession = makeValidSession()
+        networkClient.mockJWTError = AuthenticationError.serverError(statusCode: 500)
+
+        let service = makeService(storage: storage, networkClient: networkClient)
+
+        await #expect(throws: AuthenticationError.self) {
+            _ = try await service.ensureAuthenticated()
+        }
+
+        // Sign-in should have been called, but JWT exchange failed
+        #expect(networkClient.signInCallCount == 1)
+        #expect(networkClient.fetchJWTCallCount == 1)
+    }
+
+    @Test("Stored JWT session with valid expiration skips network calls")
+    func cachedJWTSessionSkipsNetwork() async throws {
+        let storage = InMemoryTokenStorage()
+        let networkClient = MockAuthNetworkClient()
+
+        // Pre-populate storage with a JWT session (has expiresAt)
+        let jwtSession = AuthSession(
+            token: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjk5OTk5OTk5OTl9.sig",
+            userId: "user-123",
+            createdAt: Date(),
+            expiresAt: Date().addingTimeInterval(3600)
+        )
+        try storage.save(jwtSession)
+
+        let service = makeService(storage: storage, networkClient: networkClient)
+        let token = try await service.ensureAuthenticated()
+
+        #expect(token == jwtSession.token)
+        #expect(networkClient.signInCallCount == 0)
+        #expect(networkClient.fetchJWTCallCount == 0)
+    }
+
+    @Test("Expired JWT session triggers full re-auth with JWT exchange")
+    func expiredJWTSessionTriggersFullReauth() async throws {
+        let storage = InMemoryTokenStorage()
+
+        // Store an expired JWT session
+        let expiredJWT = AuthSession(
+            token: "eyJhbGciOiJIUzI1NiJ9.eyJleHAiOjF9.sig",
+            userId: "user-123",
+            createdAt: Date().addingTimeInterval(-7200),
+            expiresAt: Date().addingTimeInterval(-3600)
+        )
+        try storage.save(expiredJWT)
+
+        let freshSession = makeValidSession()
+        let networkClient = makeNetworkClient(session: freshSession)
+
+        let service = makeService(storage: storage, networkClient: networkClient)
+        let token = try await service.ensureAuthenticated()
+
+        #expect(token.contains("."))
+        #expect(networkClient.signInCallCount == 1)
+        #expect(networkClient.fetchJWTCallCount == 1)
+    }
+
     // MARK: - reauthenticate Tests
 
     @Test("Reauthenticate clears cache and fetches fresh token")
     func reauthenticateClearsCacheAndRefetches() async throws {
         let storage = InMemoryTokenStorage()
-        let networkClient = MockAuthNetworkClient()
 
-        // Initial session
+        // Initial session (already in storage, bypasses network)
         let initialSession = makeValidSession()
         try storage.save(initialSession)
 
-        // Fresh session from reauthentication
+        // Fresh session from reauthentication (will go through network)
         let freshSession = makeValidSession()
-        networkClient.mockSession = freshSession
+        let networkClient = makeNetworkClient(session: freshSession)
 
         let service = makeService(storage: storage, networkClient: networkClient)
 
@@ -163,8 +239,9 @@ struct AuthenticationServiceTests {
 
         // Now reauthenticate
         let token2 = try await service.reauthenticate(reason: .unauthorized)
-        #expect(token2 == freshSession.token)
+        #expect(token2 != initialSession.token)
         #expect(networkClient.signInCallCount == 1)
+        #expect(networkClient.fetchJWTCallCount == 1)
     }
 
     // MARK: - currentUserId Tests
@@ -199,11 +276,10 @@ struct AuthenticationServiceTests {
     @Test("Sign out clears cached session and storage")
     func signOutClearsEverything() async throws {
         let storage = InMemoryTokenStorage()
-        let networkClient = MockAuthNetworkClient()
         let session = makeValidSession()
-
         try storage.save(session)
-        networkClient.mockSession = makeValidSession() // For re-auth after sign out
+
+        let networkClient = makeNetworkClient(session: makeValidSession())
 
         let service = makeService(storage: storage, networkClient: networkClient)
 
@@ -227,8 +303,8 @@ struct AuthenticationServiceTests {
     @Test("Tracks auth started and completed events")
     func tracksAuthEvents() async throws {
         let storage = InMemoryTokenStorage()
-        let networkClient = MockAuthNetworkClient()
-        networkClient.mockSession = makeValidSession()
+        let session = makeValidSession()
+        let networkClient = makeNetworkClient(session: session)
 
         let service = makeService(storage: storage, networkClient: networkClient)
         mockAnalytics.reset()
@@ -238,6 +314,21 @@ struct AuthenticationServiceTests {
         let eventNames = mockAnalytics.capturedEventNames()
         #expect(eventNames.contains("request_line_auth_started_event"))
         #expect(eventNames.contains("request_line_auth_completed_event"))
+    }
+
+    @Test("Tracks JWT exchange event on successful auth from network")
+    func tracksJWTExchangeEvent() async throws {
+        let storage = InMemoryTokenStorage()
+        let session = makeValidSession()
+        let networkClient = makeNetworkClient(session: session)
+
+        let service = makeService(storage: storage, networkClient: networkClient)
+        mockAnalytics.reset()
+
+        _ = try await service.ensureAuthenticated()
+
+        let eventNames = mockAnalytics.capturedEventNames()
+        #expect(eventNames.contains("request_line_jwt_exchange_event"))
     }
 
     @Test("Tracks auth failed event on network error")
@@ -258,4 +349,47 @@ struct AuthenticationServiceTests {
         let eventNames = mockAnalytics.capturedEventNames()
         #expect(eventNames.contains("request_line_auth_failed_event"))
     }
+
+    @Test("Tracks auth failed event with jwtExchange phase on JWT exchange error")
+    func tracksJWTExchangeFailure() async throws {
+        let storage = InMemoryTokenStorage()
+        let networkClient = MockAuthNetworkClient()
+        networkClient.mockSession = makeValidSession()
+        networkClient.mockJWTError = AuthenticationError.serverError(statusCode: 500)
+
+        let service = makeService(storage: storage, networkClient: networkClient)
+        mockAnalytics.reset()
+
+        do {
+            _ = try await service.ensureAuthenticated()
+        } catch {
+            // Expected
+        }
+
+        let failedEvents = mockAnalytics.typedEvents(ofType: RequestLineAuthFailedEvent.self)
+        let jwtExchangeFailure = failedEvents.first { $0.phase == .jwtExchange }
+        #expect(jwtExchangeFailure != nil)
+    }
+}
+
+// MARK: - Test Helpers
+
+/// Creates a test JWT with a valid payload containing the given expiration.
+///
+/// The JWT is structurally valid (three base64url segments with a decodable payload)
+/// but has a fake signature — this is sufficient for `JWTPayloadDecoder` which does
+/// not verify signatures.
+private func makeTestJWT(expiresIn: TimeInterval = 3600) -> String {
+    let header = Data("{\"alg\":\"HS256\"}".utf8).base64EncodedString()
+    let exp = Int(Date().addingTimeInterval(expiresIn).timeIntervalSince1970)
+    let payload = Data("{\"sub\":\"test\",\"exp\":\(exp)}".utf8).base64EncodedString()
+
+    func base64urlEncode(_ base64: String) -> String {
+        base64
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    return "\(base64urlEncode(header)).\(base64urlEncode(payload)).fakesignature"
 }

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/DefaultAuthNetworkClientTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/DefaultAuthNetworkClientTests.swift
@@ -162,6 +162,103 @@ struct DefaultAuthNetworkClientTests {
             _ = try await client.signInAnonymously(baseURL: "https://api.example.com")
         }
     }
+
+    // MARK: - fetchJWT Tests
+
+    @Test("fetchJWT URL uses GET /auth/token path")
+    func fetchJWTURLPath() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = validJWTTokenResponse
+        interceptor.responseStatusCode = 200
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        _ = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "session-tok")
+
+        let capturedURL = try #require(interceptor.lastRequest?.url)
+        #expect(capturedURL.path == "/auth/token")
+        #expect(capturedURL.host() == "api.example.com")
+
+        let request = try #require(interceptor.lastRequest)
+        #expect(request.httpMethod == "GET")
+    }
+
+    @Test("fetchJWT includes Authorization: Bearer header with session token")
+    func fetchJWTAuthorizationHeader() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = validJWTTokenResponse
+        interceptor.responseStatusCode = 200
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        _ = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "my-session-token")
+
+        let auth = interceptor.lastRequest?.value(forHTTPHeaderField: "Authorization")
+        #expect(auth == "Bearer my-session-token")
+    }
+
+    @Test("fetchJWT includes Origin header matching baseURL")
+    func fetchJWTOriginHeader() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = validJWTTokenResponse
+        interceptor.responseStatusCode = 200
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        _ = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "tok")
+
+        let origin = interceptor.lastRequest?.value(forHTTPHeaderField: "Origin")
+        #expect(origin == "https://api.example.com")
+    }
+
+    @Test("fetchJWT returns token string from response")
+    func fetchJWTReturnsToken() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = validJWTTokenResponse
+        interceptor.responseStatusCode = 200
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        let jwt = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "tok")
+
+        #expect(jwt == "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIiwiZXhwIjoxNzM1Njg5NjAwfQ.fakesig")
+    }
+
+    @Test("fetchJWT throws serverError for non-200 status")
+    func fetchJWTThrowsServerError() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = """
+        {"error": "Unauthorized"}
+        """.data(using: .utf8)!
+        interceptor.responseStatusCode = 401
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        await #expect(throws: AuthenticationError.self) {
+            _ = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "bad-tok")
+        }
+    }
+
+    @Test("fetchJWT throws invalidResponse for missing token field")
+    func fetchJWTThrowsInvalidResponseForMissingToken() async throws {
+        let interceptor = AuthRequestInterceptor()
+        interceptor.responseBody = """
+        {"error": "nope"}
+        """.data(using: .utf8)!
+        interceptor.responseStatusCode = 200
+
+        let session = makeSession(interceptor: interceptor)
+        let client = DefaultAuthNetworkClient(session: session)
+
+        await #expect(throws: AuthenticationError.self) {
+            _ = try await client.fetchJWT(baseURL: "https://api.example.com", sessionToken: "tok")
+        }
+    }
 }
 
 // MARK: - Test Helpers
@@ -174,6 +271,12 @@ private let validBetterAuthResponse = """
         "name": "Anonymous",
         "email": "temp@anonymous.wxyc.org"
     }
+}
+""".data(using: .utf8)!
+
+private let validJWTTokenResponse = """
+{
+    "token": "eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ1c2VyMTIzIiwiZXhwIjoxNzM1Njg5NjAwfQ.fakesig"
 }
 """.data(using: .utf8)!
 

--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/JWTPayloadDecoderTests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/JWTPayloadDecoderTests.swift
@@ -1,0 +1,128 @@
+//
+//  JWTPayloadDecoderTests.swift
+//  MusicShareKit
+//
+//  Tests for JWTPayloadDecoder base64url decoding and exp claim extraction.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Testing
+@testable import MusicShareKit
+
+@Suite("JWTPayloadDecoder Tests")
+struct JWTPayloadDecoderTests {
+
+    // MARK: - Helpers
+
+    /// Encodes a JSON payload as a base64url segment (no padding).
+    private func base64urlEncode(_ json: [String: Any]) -> String {
+        let data = try! JSONSerialization.data(withJSONObject: json)
+        return data.base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+
+    /// Builds a fake JWT string with the given payload segment.
+    private func makeJWT(payload: String) -> String {
+        "eyJhbGciOiJIUzI1NiJ9.\(payload).fakesignature"
+    }
+
+    /// Builds a fake JWT from a JSON dictionary.
+    private func makeJWT(claims: [String: Any]) -> String {
+        makeJWT(payload: base64urlEncode(claims))
+    }
+
+    // MARK: - Success Cases
+
+    @Test("Decodes valid JWT with exp claim")
+    func decodesValidJWTWithExpClaim() throws {
+        let expTimestamp: TimeInterval = 1735689600 // 2025-01-01T00:00:00Z
+        let jwt = makeJWT(claims: ["sub": "user123", "exp": expTimestamp])
+
+        let payload = try JWTPayloadDecoder.decode(jwt)
+
+        #expect(payload.expiresAt == Date(timeIntervalSince1970: expTimestamp))
+    }
+
+    @Test("Handles base64url characters (- and _)")
+    func handlesBase64URLCharacters() throws {
+        // Create a payload whose base64 encoding contains + and / characters.
+        // Use a payload with bytes that produce those characters.
+        let claims: [String: Any] = [
+            "exp": 1735689600,
+            "sub": "user???>>><<<" // likely to produce +/_ in base64
+        ]
+        let jwt = makeJWT(claims: claims)
+
+        let payload = try JWTPayloadDecoder.decode(jwt)
+
+        #expect(payload.expiresAt == Date(timeIntervalSince1970: 1735689600))
+    }
+
+    @Test("Handles payload without base64 padding")
+    func handlesPayloadWithoutPadding() throws {
+        // Payloads are stripped of = padding in JWTs
+        let claims: [String: Any] = ["exp": 1735689600]
+        let encoded = base64urlEncode(claims)
+        // Verify our helper actually stripped padding
+        #expect(!encoded.contains("="))
+
+        let jwt = makeJWT(payload: encoded)
+        let payload = try JWTPayloadDecoder.decode(jwt)
+
+        #expect(payload.expiresAt == Date(timeIntervalSince1970: 1735689600))
+    }
+
+    @Test("Decodes exp as integer")
+    func decodesExpAsInteger() throws {
+        // exp is typically an integer in JWT payloads
+        let jwt = makeJWT(claims: ["exp": 1893456000]) // 2030-01-01
+
+        let payload = try JWTPayloadDecoder.decode(jwt)
+
+        #expect(payload.expiresAt == Date(timeIntervalSince1970: 1893456000))
+    }
+
+    // MARK: - Failure Cases
+
+    @Test("Throws for token with wrong segment count")
+    func throwsForWrongSegmentCount() {
+        #expect(throws: AuthenticationError.self) {
+            _ = try JWTPayloadDecoder.decode("a.b.c.d.e")
+        }
+    }
+
+    @Test("Throws for single-segment token")
+    func throwsForSingleSegment() {
+        #expect(throws: AuthenticationError.self) {
+            _ = try JWTPayloadDecoder.decode("noperiods")
+        }
+    }
+
+    @Test("Throws for invalid base64 in payload segment")
+    func throwsForInvalidBase64() {
+        #expect(throws: AuthenticationError.self) {
+            _ = try JWTPayloadDecoder.decode("header.!!!invalid!!!.signature")
+        }
+    }
+
+    @Test("Throws for missing exp claim in payload")
+    func throwsForMissingExpClaim() {
+        let jwt = makeJWT(claims: ["sub": "user123", "iat": 1735689600])
+
+        #expect(throws: AuthenticationError.self) {
+            _ = try JWTPayloadDecoder.decode(jwt)
+        }
+    }
+
+    @Test("Throws for empty string")
+    func throwsForEmptyString() {
+        #expect(throws: AuthenticationError.self) {
+            _ = try JWTPayloadDecoder.decode("")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Add two-step auth flow: anonymous sign-in -> JWT exchange via `GET /auth/token`
- Decode JWT `exp` claim to populate `AuthSession.expiresAt` (previously always `nil`), enabling proactive token expiration
- Add `JWTPayloadDecoder` for base64url payload decoding without third-party dependencies

## Details

The Backend-Service is consolidating to JWT-only authentication (WXYC/Backend-Service#374). Once Backend-Service#376 deploys `requirePermissions({})`, session tokens will be rejected. This PR prepares the iOS app for that transition.

**Migration**: Users with old session tokens in Keychain will hit a 401 on next request, triggering the existing `reauthenticate()` flow which clears state and performs the full two-step sign-in automatically.

### Files changed

| File | Change |
|------|--------|
| `JWTPayloadDecoder.swift` | New — base64url decode JWT payload, extract `exp` claim |
| `AuthNetworkClient.swift` | Add `fetchJWT(baseURL:sessionToken:)` to protocol, default impl, and mock |
| `AuthenticationService.swift` | Update `ensureAuthenticated()` for two-step flow |
| `RequestLineAnalytics.swift` | Add `.jwtExchange` failure phase and `RequestLineJWTExchangeEvent` |

## Test plan

- [x] Unit tests: `JWTPayloadDecoderTests` — 9 tests for valid decoding, base64url edge cases, and error paths
- [x] Unit tests: `DefaultAuthNetworkClientTests` — 6 new tests for `fetchJWT` URL, headers, response parsing, and errors
- [x] Unit tests: `AuthenticationServiceTests` — 7 new tests for two-step flow, JWT caching, expiration, and analytics; 4 existing tests updated for new flow
- [x] E2E: anonymous sign-in -> JWT exchange -> verify JWT has valid `exp` claim
- [ ] E2E: JWT authenticates against `/config/secrets` (disabled until Backend-Service#376 deploys)

Closes #212