### PR TITLE
Add HLS environment picker to debug menu

### DIFF
--- a/Shared/DebugPanel/Sources/DebugPanel/VisualizerDebugView.swift
+++ b/Shared/DebugPanel/Sources/DebugPanel/VisualizerDebugView.swift
@@ -23,6 +23,7 @@ public struct VisualizerDebugView: View {
     @State private var skipNextAPIVersionPersist = false
     @State private var selectedPlayerType: PlayerControllerType = .loadPersisted()
     @State private var skipNextPlayerTypePersist = false
+    @State private var selectedHLSEnvironment: HLSEnvironment = .loadActive()
     @State private var cachePurged = false
     @Environment(\.dismiss) private var dismiss
     @Environment(\.playlistService) private var playlistService
@@ -143,10 +144,22 @@ public struct VisualizerDebugView: View {
                             newValue.persist()
                         }
                     }
+                    if selectedPlayerType == .hlsPlayer {
+                        Picker("HLS Environment", selection: $selectedHLSEnvironment) {
+                            ForEach(HLSEnvironment.allCases) { env in
+                                Text(env.displayName).tag(env)
+                            }
+                        }
+                        .onChange(of: selectedHLSEnvironment) { _, newValue in
+                            newValue.persist()
+                        }
+                    }
                     Button("Use Feature Flag") {
                         PlayerControllerType.clearPersisted()
                         skipNextPlayerTypePersist = true
                         selectedPlayerType = .loadPersisted()
+                        HLSEnvironment.clearOverride()
+                        selectedHLSEnvironment = .loadActive()
                     }
                 } header: {
                     Text("Player")

--- a/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
+++ b/Shared/Playback/Sources/PlaybackAPI/AudioPlayerController.swift
@@ -71,7 +71,7 @@ public final class AudioPlayerController {
         case .radioPlayer:
             RadioPlayer()
         case .hlsPlayer:
-            HLSPlayer(url: RadioStation.WXYC.hlsStreamURL)
+            HLSPlayer(url: HLSEnvironment.loadActive().url)
         }
     }
     #endif

--- a/Shared/Playback/Sources/PlaybackCore/PlayerControllerType.swift
+++ b/Shared/Playback/Sources/PlaybackCore/PlayerControllerType.swift
@@ -10,6 +10,7 @@
 
 import Analytics
 import Caching
+import Core
 import Foundation
 
 /// Available PlaybackController implementations
@@ -110,6 +111,79 @@ public enum PlayerControllerType: String, CaseIterable, Identifiable, Hashable, 
             "URLSession + AudioToolbox. Supports visualizer."
         case .hlsPlayer:
             "AVPlayer with HLS. Supports time-shift scrub bar, no visualizer."
+        }
+    }
+}
+
+// MARK: - HLS Environment
+
+/// HLS backend environment (production vs staging).
+///
+/// Selectable in the debug menu when HLSPlayer is active. Defaults to production.
+public enum HLSEnvironment: String, CaseIterable, Identifiable, Hashable, Sendable {
+    case production
+    case staging
+
+    // MARK: - URL
+
+    public var url: URL {
+        switch self {
+        case .production:
+            RadioStation.WXYC.hlsStreamURL
+        case .staging:
+            URL(string: "https://hls-staging.wxyc.org/live/live.m3u8")!
+        }
+    }
+
+    // MARK: - Persistence
+
+    private static var defaults: UserDefaults { .wxyc }
+    private static let userDefaultsKey = "debug.selectedHLSEnvironment"
+    private static let manualSelectionKey = "debug.isHLSEnvironmentManuallySelected"
+
+    public static func loadActive() -> HLSEnvironment {
+        loadActive(from: defaults)
+    }
+
+    static func loadActive(from defaults: DefaultsStorage) -> HLSEnvironment {
+        if defaults.bool(forKey: manualSelectionKey),
+           let rawValue = defaults.string(forKey: userDefaultsKey),
+           let env = HLSEnvironment(rawValue: rawValue) {
+            return env
+        }
+        return .production
+    }
+
+    public func persist() {
+        persist(to: Self.defaults)
+    }
+
+    func persist(to defaults: DefaultsStorage) {
+        defaults.set(rawValue, forKey: Self.userDefaultsKey)
+        defaults.set(true, forKey: Self.manualSelectionKey)
+    }
+
+    public static func clearOverride() {
+        clearOverride(from: defaults)
+    }
+
+    static func clearOverride(from defaults: DefaultsStorage) {
+        defaults.removeObject(forKey: userDefaultsKey)
+        defaults.removeObject(forKey: manualSelectionKey)
+    }
+
+    // MARK: - Identifiable
+
+    public var id: String { rawValue }
+
+    // MARK: - Display
+
+    public var displayName: String {
+        switch self {
+        case .production:
+            "Production (hls.wxyc.org)"
+        case .staging:
+            "Staging (hls-staging.wxyc.org)"
         }
     }
 }

--- a/Shared/Playback/Tests/PlaybackTests/PlayerControllerTypeTests.swift
+++ b/Shared/Playback/Tests/PlaybackTests/PlayerControllerTypeTests.swift
@@ -80,3 +80,45 @@ struct PlayerControllerTypeTests {
         #expect(PlayerControllerType.hlsPlayer.displayName.contains("HLS"))
     }
 }
+
+@Suite("HLSEnvironment Tests")
+@MainActor
+struct HLSEnvironmentTests {
+
+    init() {
+        HLSEnvironment.clearOverride()
+    }
+
+    @Test("Default environment is production")
+    func defaultIsProduction() {
+        #expect(HLSEnvironment.loadActive() == .production)
+    }
+
+    @Test("Manual override persists and loads")
+    func manualOverride() {
+        HLSEnvironment.staging.persist()
+        #expect(HLSEnvironment.loadActive() == .staging)
+    }
+
+    @Test("Clearing override reverts to default")
+    func clearOverride() {
+        HLSEnvironment.staging.persist()
+        HLSEnvironment.clearOverride()
+        #expect(HLSEnvironment.loadActive() == .production)
+    }
+
+    @Test("Each environment has a distinct URL", arguments: HLSEnvironment.allCases)
+    func urlIsNonEmpty(env: HLSEnvironment) {
+        #expect(!env.url.absoluteString.isEmpty)
+    }
+
+    @Test("Staging URL points to staging host")
+    func stagingURLIsCorrect() {
+        #expect(HLSEnvironment.staging.url.host() == "hls-staging.wxyc.org")
+    }
+
+    @Test("Production URL points to production host")
+    func productionURLIsCorrect() {
+        #expect(HLSEnvironment.production.url.host() == "hls.wxyc.org")
+    }
+}


### PR DESCRIPTION
## Summary

- Add `HLSEnvironment` enum (production / staging) with UserDefaults persistence, following the same pattern as `PlayerControllerType` and `PlaylistAPIVersion`
- Show an "HLS Environment" picker in the debug menu when the HLS player is selected, allowing testers to switch between `hls.wxyc.org` and `hls-staging.wxyc.org`
- `AudioPlayerController.makePlayer` reads the active environment when creating the HLS player
- "Use Feature Flag" resets both player type and HLS environment

## Test plan

- [x] 12 tests pass across `PlayerControllerTypeTests` and `HLSEnvironmentTests`
- [ ] Debug menu → select HLS player → "HLS Environment" picker appears
- [ ] Select Staging → restart → app connects to `hls-staging.wxyc.org`
- [ ] Tap "Use Feature Flag" → environment resets to Production