### PR TITLE
Add WXYC Recommends with semantic-index integration

### DIFF
--- a/Shared/Analytics/Sources/Analytics/Events/UIEvents.swift
+++ b/Shared/Analytics/Sources/Analytics/Events/UIEvents.swift
@@ -74,6 +74,30 @@ public struct ExternalLinkTapped {
     }
 }
 
+// MARK: - WXYC Recommends
+
+/// Event fired when a recommended artist is tapped in the WXYC Recommends section.
+@AnalyticsEvent
+public struct RecommendedArtistTapped {
+    public let sourceArtist: String
+    public let recommendedArtist: String
+
+    public init(sourceArtist: String, recommendedArtist: String) {
+        self.sourceArtist = sourceArtist
+        self.recommendedArtist = recommendedArtist
+    }
+}
+
+/// Event fired when an artist detail view is presented from WXYC Recommends.
+@AnalyticsEvent
+public struct ArtistDetailViewPresented {
+    public let artist: String
+
+    public init(artist: String) {
+        self.artist = artist
+    }
+}
+
 // MARK: - CarPlay
 
 /// Event fired when CarPlay connects.

--- a/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
+++ b/Shared/Metadata/Sources/Metadata/PlaycutMetadataService.swift
@@ -81,6 +81,18 @@ public actor PlaycutMetadataService {
         )
     }
 
+    /// Fetches artist bio text by Discogs artist ID.
+    ///
+    /// Used by ArtistDetailView to display bio for recommended artists that
+    /// have a known Discogs artist ID from the semantic-index.
+    ///
+    /// - Parameter discogsArtistId: The Discogs artist ID.
+    /// - Returns: The artist bio string, or `nil` if unavailable.
+    public func fetchArtistBio(discogsArtistId: Int) async -> String? {
+        let metadata = await fetchArtistMetadata(discogsArtistId: discogsArtistId)
+        return metadata.bio
+    }
+
     // MARK: - Granular Caching Methods
 
     /// Fetches artist metadata, caching by Discogs artist ID.

--- a/Shared/SemanticIndex/Package.swift
+++ b/Shared/SemanticIndex/Package.swift
@@ -1,0 +1,23 @@
+// swift-tools-version:6.2
+import PackageDescription
+
+let package = Package(
+    name: "SemanticIndex",
+    platforms: [.iOS("18.4"), .watchOS(.v11), .macOS(.v15)],
+    products: [.library(name: "SemanticIndex", targets: ["SemanticIndex"])],
+    dependencies: [
+        .package(name: "Core", path: "../Core"),
+        .package(name: "Caching", path: "../Caching"),
+        .package(name: "Logger", path: "../Logger"),
+    ],
+    targets: [
+        .target(
+            name: "SemanticIndex",
+            dependencies: ["Core", "Caching", "Logger"]
+        ),
+        .testTarget(
+            name: "SemanticIndexTests",
+            dependencies: ["SemanticIndex", "Caching"]
+        )
+    ]
+)

--- a/Shared/SemanticIndex/Sources/SemanticIndex/ArtistStreamingLinks.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/ArtistStreamingLinks.swift
@@ -1,0 +1,53 @@
+//
+//  ArtistStreamingLinks.swift
+//  SemanticIndex
+//
+//  Constructs streaming service URLs from semantic-index artist detail
+//  and preview data. Used by ArtistStreamingLinksSection in the UI.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Streaming service URLs for an artist, constructed from semantic-index data.
+///
+/// Prefers the Apple Music album link from the preview endpoint when available,
+/// falling back to the artist page. Spotify and Bandcamp always link to the
+/// artist page.
+public struct ArtistStreamingLinks: Sendable {
+    /// Apple Music URL — album page (from preview) or artist page (from detail).
+    public let appleMusicURL: URL?
+
+    /// Spotify artist page URL.
+    public let spotifyURL: URL?
+
+    /// Bandcamp artist page URL.
+    public let bandcampURL: URL?
+
+    /// Creates streaming links from artist detail and optional preview data.
+    ///
+    /// - Parameters:
+    ///   - detail: The artist detail containing streaming service IDs.
+    ///   - preview: Optional preview data containing Apple Music album link.
+    public init(detail: SemanticIndexArtistDetail, preview: SemanticIndexPreview? = nil) {
+        self.appleMusicURL = preview?.albumURL
+            ?? detail.appleMusicArtistId.flatMap {
+                URL(string: "https://music.apple.com/artist/\($0)")
+            }
+
+        self.spotifyURL = detail.spotifyArtistId.flatMap {
+            URL(string: "https://open.spotify.com/artist/\($0)")
+        }
+
+        self.bandcampURL = detail.bandcampId.flatMap {
+            URL(string: "https://\($0).bandcamp.com")
+        }
+    }
+
+    /// Whether any streaming links are available.
+    public var hasLinks: Bool {
+        appleMusicURL != nil || spotifyURL != nil || bandcampURL != nil
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexArtist.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexArtist.swift
@@ -1,0 +1,37 @@
+//
+//  SemanticIndexArtist.swift
+//  SemanticIndex
+//
+//  Artist summary from the semantic-index search endpoint. Maps to
+//  the API's ArtistSummary response model.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// An artist summary returned by the semantic-index search endpoint.
+///
+/// Contains the artist's graph ID, canonical name, genre classification,
+/// and total play count across WXYC's 22-year flowsheet history.
+public struct SemanticIndexArtist: Codable, Sendable, Hashable, Identifiable {
+    public let id: Int
+    public let canonicalName: String
+    public let genre: String?
+    public let totalPlays: Int?
+
+    public init(id: Int, canonicalName: String, genre: String? = nil, totalPlays: Int? = nil) {
+        self.id = id
+        self.canonicalName = canonicalName
+        self.genre = genre
+        self.totalPlays = totalPlays
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case canonicalName = "canonical_name"
+        case genre
+        case totalPlays = "total_plays"
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexArtistDetail.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexArtistDetail.swift
@@ -1,0 +1,59 @@
+//
+//  SemanticIndexArtistDetail.swift
+//  SemanticIndex
+//
+//  Full artist detail from the semantic-index artist endpoint. Extends
+//  the basic summary with streaming service IDs and Discogs artist ID.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Full artist detail returned by the semantic-index artist detail endpoint.
+///
+/// Includes streaming service identifiers (Spotify, Apple Music, Bandcamp)
+/// and the Discogs artist ID for fetching artist bio via the existing
+/// metadata proxy.
+public struct SemanticIndexArtistDetail: Codable, Sendable, Hashable {
+    public let id: Int
+    public let canonicalName: String
+    public let genre: String?
+    public let totalPlays: Int?
+    public let spotifyArtistId: String?
+    public let appleMusicArtistId: String?
+    public let bandcampId: String?
+    public let discogsArtistId: Int?
+
+    public init(
+        id: Int,
+        canonicalName: String,
+        genre: String? = nil,
+        totalPlays: Int? = nil,
+        spotifyArtistId: String? = nil,
+        appleMusicArtistId: String? = nil,
+        bandcampId: String? = nil,
+        discogsArtistId: Int? = nil
+    ) {
+        self.id = id
+        self.canonicalName = canonicalName
+        self.genre = genre
+        self.totalPlays = totalPlays
+        self.spotifyArtistId = spotifyArtistId
+        self.appleMusicArtistId = appleMusicArtistId
+        self.bandcampId = bandcampId
+        self.discogsArtistId = discogsArtistId
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id
+        case canonicalName = "canonical_name"
+        case genre
+        case totalPlays = "total_plays"
+        case spotifyArtistId = "spotify_artist_id"
+        case appleMusicArtistId = "apple_music_artist_id"
+        case bandcampId = "bandcamp_id"
+        case discogsArtistId = "discogs_artist_id"
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexCacheKey.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexCacheKey.swift
@@ -1,0 +1,56 @@
+//
+//  SemanticIndexCacheKey.swift
+//  SemanticIndex
+//
+//  Cache key generation for semantic-index API responses.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Utility for generating consistent cache keys for semantic-index API responses.
+///
+/// Cache keys are prefixed with `si-` to avoid collisions with metadata cache keys.
+/// Each endpoint has its own key format and TTL:
+/// - Search: 7-day TTL (artist name to ID mapping, stable between graph rebuilds)
+/// - Neighbors: 7-day TTL (transition weights update with pipeline runs)
+/// - Artist detail: 30-day TTL (streaming IDs are very stable)
+/// - Preview: 30-day TTL (iTunes data is very stable)
+public enum SemanticIndexCacheKey {
+
+    /// Cache key for artist search results, keyed by artist name.
+    ///
+    /// - Parameter name: The artist name used in the search query.
+    /// - Returns: Cache key in format `si-search-{name}`
+    public static func search(name: String) -> String {
+        "si-search-\(name)"
+    }
+
+    /// Cache key for artist neighbors, keyed by artist ID and heat parameter.
+    ///
+    /// - Parameters:
+    ///   - artistId: The semantic-index artist ID.
+    ///   - heat: The heat parameter used in the query.
+    /// - Returns: Cache key in format `si-neighbors-{artistId}-{heat}`
+    public static func neighbors(artistId: Int, heat: Double) -> String {
+        "si-neighbors-\(artistId)-\(heat)"
+    }
+
+    /// Cache key for artist detail, keyed by artist ID.
+    ///
+    /// - Parameter id: The semantic-index artist ID.
+    /// - Returns: Cache key in format `si-artist-{id}`
+    public static func artistDetail(id: Int) -> String {
+        "si-artist-\(id)"
+    }
+
+    /// Cache key for artist preview data, keyed by artist ID.
+    ///
+    /// - Parameter id: The semantic-index artist ID.
+    /// - Returns: Cache key in format `si-preview-{id}`
+    public static func preview(id: Int) -> String {
+        "si-preview-\(id)"
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexNeighbor.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexNeighbor.swift
@@ -1,0 +1,48 @@
+//
+//  SemanticIndexNeighbor.swift
+//  SemanticIndex
+//
+//  A neighbor entry from the semantic-index neighbors endpoint. Represents
+//  a DJ-validated transition between two artists in the WXYC flowsheet graph.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// A neighbor entry from the semantic-index neighbors endpoint.
+///
+/// Each neighbor represents an artist that WXYC DJs have historically
+/// transitioned to or from the source artist. The `weight` reflects
+/// how strong the transition relationship is, and `detail` provides
+/// the underlying statistics.
+public struct SemanticIndexNeighbor: Codable, Sendable, Hashable, Identifiable {
+    public var id: Int { artist.id }
+
+    public let artist: SemanticIndexArtist
+    public let weight: Double
+    public let detail: TransitionDetail?
+
+    public init(artist: SemanticIndexArtist, weight: Double, detail: TransitionDetail? = nil) {
+        self.artist = artist
+        self.weight = weight
+        self.detail = detail
+    }
+
+    /// Statistics underlying a DJ transition relationship.
+    public struct TransitionDetail: Codable, Sendable, Hashable {
+        public let rawCount: Int
+        public let pmi: Double
+
+        public init(rawCount: Int, pmi: Double) {
+            self.rawCount = rawCount
+            self.pmi = pmi
+        }
+
+        private enum CodingKeys: String, CodingKey {
+            case rawCount = "raw_count"
+            case pmi
+        }
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexPreview.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexPreview.swift
@@ -1,0 +1,60 @@
+//
+//  SemanticIndexPreview.swift
+//  SemanticIndex
+//
+//  Preview data from the semantic-index preview endpoint, providing
+//  iTunes artwork, track names, and Apple Music album links.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// Preview data from the semantic-index artist preview endpoint.
+///
+/// Provides artwork URLs, track names, and Apple Music album deep links
+/// sourced from the iTunes Search API cache in the Transition Player backend.
+public struct SemanticIndexPreview: Codable, Sendable, Hashable {
+    public let previewUrl: String?
+    public let trackName: String?
+    public let artistName: String?
+    public let artworkUrl: String?
+    public let albumName: String?
+    public let albumUrl: String?
+
+    public init(
+        previewUrl: String? = nil,
+        trackName: String? = nil,
+        artistName: String? = nil,
+        artworkUrl: String? = nil,
+        albumName: String? = nil,
+        albumUrl: String? = nil
+    ) {
+        self.previewUrl = previewUrl
+        self.trackName = trackName
+        self.artistName = artistName
+        self.artworkUrl = artworkUrl
+        self.albumName = albumName
+        self.albumUrl = albumUrl
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case previewUrl = "preview_url"
+        case trackName = "track_name"
+        case artistName = "artist_name"
+        case artworkUrl = "artwork_url"
+        case albumName = "album_name"
+        case albumUrl = "album_url"
+    }
+
+    /// The artwork URL as a typed `URL`, or `nil` if the string is missing or invalid.
+    public var artworkURL: URL? {
+        artworkUrl.flatMap { URL(string: $0) }
+    }
+
+    /// The Apple Music album URL as a typed `URL`, or `nil` if the string is missing or invalid.
+    public var albumURL: URL? {
+        albumUrl.flatMap { URL(string: $0) }
+    }
+}

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
@@ -1,0 +1,216 @@
+//
+//  SemanticIndexService.swift
+//  SemanticIndex
+//
+//  API client for the WXYC semantic-index graph service (explore.wxyc.org).
+//  Provides artist search, neighbor lookups, and detail fetching with
+//  multi-level caching.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Core
+import Caching
+import Logger
+import struct Logger.Category
+
+/// API client for the WXYC semantic-index graph service.
+///
+/// The semantic-index encodes 22 years of WXYC DJ transition data as a graph.
+/// This service provides:
+/// - Artist search by name
+/// - Neighbor lookups for DJ-validated transitions
+/// - Artist detail with streaming service IDs
+/// - Preview data with artwork and Apple Music links
+///
+/// All responses are cached via ``CacheCoordinator`` to reduce redundant API calls.
+public actor SemanticIndexService {
+    private let baseURL: URL
+    private let session: WebSession
+    private let cache: CacheCoordinator
+    private let errorReporter: any ErrorReporter
+
+    public init(
+        baseURL: URL = URL(string: "https://explore.wxyc.org")!,
+        errorReporter: any ErrorReporter = ErrorReporting.shared
+    ) {
+        self.baseURL = baseURL
+        self.session = URLSession.shared
+        self.cache = .Metadata
+        self.errorReporter = errorReporter
+    }
+
+    init(
+        baseURL: URL = URL(string: "https://explore.wxyc.org")!,
+        session: WebSession,
+        cache: CacheCoordinator = .Metadata,
+        errorReporter: any ErrorReporter = ErrorReporting.shared
+    ) {
+        self.baseURL = baseURL
+        self.session = session
+        self.cache = cache
+        self.errorReporter = errorReporter
+    }
+
+    // MARK: - Public API
+
+    /// Searches for an artist by name in the semantic-index graph.
+    ///
+    /// - Parameter name: The artist name to search for.
+    /// - Returns: The best-matching artist, or `nil` if not found.
+    public func searchArtist(name: String) async -> SemanticIndexArtist? {
+        let cacheKey = SemanticIndexCacheKey.search(name: name)
+
+        let results: [SemanticIndexArtist]? = await timedOperation(
+            context: "searchArtist(\(name))",
+            category: .network,
+            fallback: nil,
+            errorReporter: errorReporter
+        ) {
+            try await cachedFetch(
+                key: cacheKey,
+                cache: cache,
+                lifespan: .sevenDays,
+                fetch: {
+                    try await fetchJSON(
+                        path: "graph/artists/search",
+                        queryItems: [
+                            URLQueryItem(name: "q", value: name),
+                            URLQueryItem(name: "limit", value: "1"),
+                        ]
+                    )
+                }
+            )
+        }
+
+        return results?.first
+    }
+
+    /// Fetches the top neighbors (DJ transitions) for an artist.
+    ///
+    /// - Parameters:
+    ///   - artistId: The semantic-index artist ID.
+    ///   - heat: The heat parameter (0.0 = cool/predictable, 1.0 = hot/surprising). Defaults to 0.0.
+    ///   - limit: Maximum number of neighbors to return. Defaults to 3.
+    /// - Returns: The neighbor entries, or an empty array on failure.
+    public func neighbors(for artistId: Int, heat: Double = 0.0, limit: Int = 3) async -> [SemanticIndexNeighbor] {
+        let cacheKey = SemanticIndexCacheKey.neighbors(artistId: artistId, heat: heat)
+
+        return await timedOperation(
+            context: "neighbors(\(artistId), heat=\(heat))",
+            category: .network,
+            fallback: [],
+            errorReporter: errorReporter
+        ) {
+            try await cachedFetch(
+                key: cacheKey,
+                cache: cache,
+                lifespan: .sevenDays,
+                fetch: {
+                    try await fetchJSON(
+                        path: "graph/artists/\(artistId)/neighbors",
+                        queryItems: [
+                            URLQueryItem(name: "type", value: "djTransition"),
+                            URLQueryItem(name: "heat", value: String(heat)),
+                            URLQueryItem(name: "limit", value: String(limit)),
+                        ]
+                    )
+                },
+                fallback: { [] }
+            )
+        }
+    }
+
+    /// Fetches full detail for an artist, including streaming service IDs.
+    ///
+    /// - Parameter id: The semantic-index artist ID.
+    /// - Returns: The artist detail, or `nil` on failure.
+    public func artistDetail(id: Int) async -> SemanticIndexArtistDetail? {
+        let cacheKey = SemanticIndexCacheKey.artistDetail(id: id)
+
+        return await timedOperation(
+            context: "artistDetail(\(id))",
+            category: .network,
+            fallback: nil,
+            errorReporter: errorReporter
+        ) {
+            try await cachedFetch(
+                key: cacheKey,
+                cache: cache,
+                lifespan: .thirtyDays,
+                fetch: {
+                    try await fetchJSON(
+                        path: "graph/artists/\(id)",
+                        queryItems: []
+                    )
+                }
+            )
+        }
+    }
+
+    /// Fetches preview data (artwork, track, album URL) for an artist.
+    ///
+    /// - Parameter artistId: The semantic-index artist ID.
+    /// - Returns: The preview data, or `nil` on failure.
+    public func preview(for artistId: Int) async -> SemanticIndexPreview? {
+        let cacheKey = SemanticIndexCacheKey.preview(id: artistId)
+
+        return await timedOperation(
+            context: "preview(\(artistId))",
+            category: .network,
+            fallback: nil,
+            errorReporter: errorReporter
+        ) {
+            try await cachedFetch(
+                key: cacheKey,
+                cache: cache,
+                lifespan: .thirtyDays,
+                fetch: {
+                    try await fetchJSON(
+                        path: "graph/artists/\(artistId)/preview",
+                        queryItems: []
+                    )
+                }
+            )
+        }
+    }
+
+    /// Convenience method that chains search + neighbors to get recommendations for an artist by name.
+    ///
+    /// - Parameter artistName: The artist name to search for.
+    /// - Returns: The top neighbor entries, or an empty array if the artist is not in the graph.
+    public func recommendations(forArtistNamed artistName: String) async -> [SemanticIndexNeighbor] {
+        guard let artist = await searchArtist(name: artistName) else {
+            return []
+        }
+
+        return await neighbors(for: artist.id)
+    }
+
+    // MARK: - Network
+
+    private func fetchJSON<T: Codable & Sendable>(path: String, queryItems: [URLQueryItem]) async throws -> T {
+        var components = URLComponents(url: baseURL.appending(path: path), resolvingAgainstBaseURL: false)!
+
+        if !queryItems.isEmpty {
+            components.queryItems = queryItems
+        }
+
+        guard let url = components.url else {
+            throw SemanticIndexError.invalidURL
+        }
+
+        let data = try await session.data(from: url)
+        return try JSONDecoder.shared.decode(T.self, from: data)
+    }
+}
+
+// MARK: - Errors
+
+extension SemanticIndexService {
+    enum SemanticIndexError: Error {
+        case invalidURL
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/ArtistStreamingLinksTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/ArtistStreamingLinksTests.swift
@@ -1,0 +1,85 @@
+//
+//  ArtistStreamingLinksTests.swift
+//  SemanticIndex
+//
+//  Tests for streaming link URL construction from semantic-index data.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+@testable import SemanticIndex
+
+@Suite("ArtistStreamingLinks")
+struct ArtistStreamingLinksTests {
+
+    @Test("Constructs Spotify URL from artist ID")
+    func spotifyURL() {
+        let detail = SemanticIndexArtistDetail(
+            id: 1,
+            canonicalName: "Stereolab",
+            spotifyArtistId: "abc123"
+        )
+        let links = ArtistStreamingLinks(detail: detail)
+        #expect(links.spotifyURL == URL(string: "https://open.spotify.com/artist/abc123"))
+    }
+
+    @Test("Constructs Bandcamp URL from bandcamp ID")
+    func bandcampURL() {
+        let detail = SemanticIndexArtistDetail(
+            id: 1,
+            canonicalName: "Broadcast",
+            bandcampId: "broadcast"
+        )
+        let links = ArtistStreamingLinks(detail: detail)
+        #expect(links.bandcampURL == URL(string: "https://broadcast.bandcamp.com"))
+    }
+
+    @Test("Prefers Apple Music album URL from preview over artist page")
+    func appleMusicPrefersAlbumURL() {
+        let detail = SemanticIndexArtistDetail(
+            id: 1,
+            canonicalName: "Tortoise",
+            appleMusicArtistId: "artist456"
+        )
+        let preview = SemanticIndexPreview(
+            albumUrl: "https://music.apple.com/album/tnt/123456"
+        )
+        let links = ArtistStreamingLinks(detail: detail, preview: preview)
+        #expect(links.appleMusicURL == URL(string: "https://music.apple.com/album/tnt/123456"))
+    }
+
+    @Test("Falls back to Apple Music artist page when preview has no album URL")
+    func appleMusicFallsBackToArtistPage() {
+        let detail = SemanticIndexArtistDetail(
+            id: 1,
+            canonicalName: "Tortoise",
+            appleMusicArtistId: "artist456"
+        )
+        let links = ArtistStreamingLinks(detail: detail)
+        #expect(links.appleMusicURL == URL(string: "https://music.apple.com/artist/artist456"))
+    }
+
+    @Test("All links nil when no streaming IDs present")
+    func noStreamingIDs() {
+        let detail = SemanticIndexArtistDetail(id: 1, canonicalName: "Unknown Artist")
+        let links = ArtistStreamingLinks(detail: detail)
+        #expect(links.appleMusicURL == nil)
+        #expect(links.spotifyURL == nil)
+        #expect(links.bandcampURL == nil)
+        #expect(!links.hasLinks)
+    }
+
+    @Test("hasLinks returns true when at least one link is present")
+    func hasLinksReturnsTrue() {
+        let detail = SemanticIndexArtistDetail(
+            id: 1,
+            canonicalName: "Laetitia Sadier",
+            spotifyArtistId: "xyz"
+        )
+        let links = ArtistStreamingLinks(detail: detail)
+        #expect(links.hasLinks)
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/Mocks.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/Mocks.swift
@@ -1,0 +1,84 @@
+//
+//  Mocks.swift
+//  SemanticIndex
+//
+//  Shared mock objects for SemanticIndex service tests.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+import Core
+@testable import Caching
+
+// MARK: - Mock WebSession
+
+final class MockWebSession: WebSession, @unchecked Sendable {
+    var responses: [String: Data] = [:]
+    var requestedURLs: [URL] = []
+    var requestCount = 0
+
+    func data(from url: URL) async throws -> Data {
+        requestCount += 1
+        requestedURLs.append(url)
+
+        for (pattern, data) in responses {
+            if url.absoluteString.contains(pattern) {
+                return data
+            }
+        }
+
+        throw ServiceError.noResults
+    }
+}
+
+// MARK: - Mock Cache
+
+final class MockCache: Cache, @unchecked Sendable {
+    private var dataStorage: [String: Data] = [:]
+    private var metadataStorage: [String: CacheMetadata] = [:]
+    var getCallCount = 0
+    var setCallCount = 0
+    var accessedKeys: [String] = []
+    var setKeys: [String] = []
+
+    func metadata(for key: String) -> CacheMetadata? {
+        getCallCount += 1
+        accessedKeys.append(key)
+        return metadataStorage[key]
+    }
+
+    func data(for key: String) -> Data? {
+        dataStorage[key]
+    }
+
+    func set(_ data: Data?, metadata: CacheMetadata, for key: String) {
+        setCallCount += 1
+        setKeys.append(key)
+        if let data {
+            dataStorage[key] = data
+            metadataStorage[key] = metadata
+        } else {
+            remove(for: key)
+        }
+    }
+
+    func remove(for key: String) {
+        dataStorage.removeValue(forKey: key)
+        metadataStorage.removeValue(forKey: key)
+    }
+
+    func allMetadata() -> [(key: String, metadata: CacheMetadata)] {
+        metadataStorage.map { ($0.key, $0.value) }
+    }
+
+    func clearAll() {
+        dataStorage.removeAll()
+        metadataStorage.removeAll()
+    }
+
+    func totalSize() -> Int64 {
+        dataStorage.values.reduce(0) { $0 + Int64($1.count) }
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceArtistDetailTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceArtistDetailTests.swift
@@ -1,0 +1,140 @@
+//
+//  SemanticIndexServiceArtistDetailTests.swift
+//  SemanticIndex
+//
+//  Tests for SemanticIndexService artist detail and preview fetching.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import Caching
+@testable import SemanticIndex
+
+@Suite("SemanticIndexService Artist Detail")
+struct SemanticIndexServiceArtistDetailTests {
+
+    @Test("Decodes artist detail with streaming IDs")
+    func decodesArtistDetail() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42"] = """
+        {
+            "id": 42,
+            "canonical_name": "Stereolab",
+            "genre": "Rock",
+            "total_plays": 500,
+            "spotify_artist_id": "sp123",
+            "apple_music_artist_id": "am456",
+            "bandcamp_id": "stereolab",
+            "discogs_artist_id": 99999
+        }
+        """.data(using: .utf8)!
+
+        let detail = await service.artistDetail(id: 42)
+
+        let result = try #require(detail)
+        #expect(result.id == 42)
+        #expect(result.canonicalName == "Stereolab")
+        #expect(result.spotifyArtistId == "sp123")
+        #expect(result.appleMusicArtistId == "am456")
+        #expect(result.bandcampId == "stereolab")
+        #expect(result.discogsArtistId == 99999)
+    }
+
+    @Test("Handles nil streaming IDs gracefully")
+    func handlesNilStreamingIDs() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42"] = """
+        {
+            "id": 42,
+            "canonical_name": "Broadcast",
+            "genre": "Electronic",
+            "total_plays": 300
+        }
+        """.data(using: .utf8)!
+
+        let detail = await service.artistDetail(id: 42)
+
+        let result = try #require(detail)
+        #expect(result.spotifyArtistId == nil)
+        #expect(result.appleMusicArtistId == nil)
+        #expect(result.bandcampId == nil)
+        #expect(result.discogsArtistId == nil)
+    }
+
+    @Test("Returns nil on API error")
+    func returnsNilOnError() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        let detail = await service.artistDetail(id: 42)
+        #expect(detail == nil)
+    }
+
+    @Test("Decodes preview data with artwork and album URL")
+    func decodesPreviewData() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42/preview"] = """
+        {
+            "preview_url": "https://audio.itunes.apple.com/preview.m4a",
+            "track_name": "French Disko",
+            "artist_name": "Stereolab",
+            "artwork_url": "https://is1.mzstatic.com/image/thumb/Music/artwork.jpg",
+            "album_name": "Transient Random-Noise Bursts with Announcements",
+            "album_url": "https://music.apple.com/album/transient/123"
+        }
+        """.data(using: .utf8)!
+
+        let preview = await service.preview(for: 42)
+
+        let result = try #require(preview)
+        #expect(result.trackName == "French Disko")
+        #expect(result.artistName == "Stereolab")
+        #expect(result.albumName == "Transient Random-Noise Bursts with Announcements")
+        #expect(result.artworkURL == URL(string: "https://is1.mzstatic.com/image/thumb/Music/artwork.jpg"))
+        #expect(result.albumURL == URL(string: "https://music.apple.com/album/transient/123"))
+    }
+
+    @Test("Returns nil preview on API error")
+    func returnsNilPreviewOnError() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        let preview = await service.preview(for: 42)
+        #expect(preview == nil)
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceNeighborsTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceNeighborsTests.swift
@@ -1,0 +1,91 @@
+//
+//  SemanticIndexServiceNeighborsTests.swift
+//  SemanticIndex
+//
+//  Tests for SemanticIndexService neighbor/transition lookup functionality.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import Caching
+@testable import SemanticIndex
+
+@Suite("SemanticIndexService Neighbors")
+struct SemanticIndexServiceNeighborsTests {
+
+    @Test("Constructs correct neighbors URL with heat parameter")
+    func constructsCorrectNeighborsURL() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42/neighbors"] = "[]".data(using: .utf8)!
+
+        _ = await service.neighbors(for: 42, heat: 0.0, limit: 3)
+
+        #expect(mockSession.requestCount == 1)
+        let url = try #require(mockSession.requestedURLs.first)
+        #expect(url.path().contains("graph/artists/42/neighbors"))
+        #expect(url.absoluteString.contains("type=djTransition"))
+        #expect(url.absoluteString.contains("heat=0.0"))
+        #expect(url.absoluteString.contains("limit=3"))
+    }
+
+    @Test("Decodes neighbors with transition detail")
+    func decodesNeighbors() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42/neighbors"] = """
+        [
+            {
+                "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
+                "weight": 0.85,
+                "detail": {"raw_count": 15, "pmi": 2.3}
+            },
+            {
+                "artist": {"id": 20, "canonical_name": "Laetitia Sadier", "genre": "Rock", "total_plays": 150},
+                "weight": 0.72,
+                "detail": {"raw_count": 10, "pmi": 1.8}
+            }
+        ]
+        """.data(using: .utf8)!
+
+        let neighbors = await service.neighbors(for: 42)
+
+        #expect(neighbors.count == 2)
+        #expect(neighbors[0].artist.canonicalName == "Tortoise")
+        #expect(neighbors[0].weight == 0.85)
+        let detail = try #require(neighbors[0].detail)
+        #expect(detail.rawCount == 15)
+        #expect(detail.pmi == 2.3)
+        #expect(neighbors[1].artist.canonicalName == "Laetitia Sadier")
+    }
+
+    @Test("Returns empty array on API error")
+    func returnsEmptyOnError() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        let neighbors = await service.neighbors(for: 42)
+        #expect(neighbors.isEmpty)
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceRecommendationsTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceRecommendationsTests.swift
@@ -1,0 +1,105 @@
+//
+//  SemanticIndexServiceRecommendationsTests.swift
+//  SemanticIndex
+//
+//  Tests for the convenience recommendations method that chains search + neighbors.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import Caching
+@testable import SemanticIndex
+
+@Suite("SemanticIndexService Recommendations")
+struct SemanticIndexServiceRecommendationsTests {
+
+    @Test("Chains search and neighbors for a known artist")
+    func chainsSearchAndNeighbors() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = """
+        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        """.data(using: .utf8)!
+
+        mockSession.responses["graph/artists/42/neighbors"] = """
+        [
+            {
+                "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
+                "weight": 0.85,
+                "detail": {"raw_count": 15, "pmi": 2.3}
+            }
+        ]
+        """.data(using: .utf8)!
+
+        let recommendations = await service.recommendations(forArtistNamed: "Stereolab")
+
+        #expect(recommendations.count == 1)
+        #expect(recommendations[0].artist.canonicalName == "Tortoise")
+        #expect(mockSession.requestCount == 2)
+    }
+
+    @Test("Returns empty when artist not found in graph")
+    func returnsEmptyWhenArtistNotFound() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = "[]".data(using: .utf8)!
+
+        let recommendations = await service.recommendations(forArtistNamed: "Unknown")
+
+        #expect(recommendations.isEmpty)
+        // Should only make one call (search) — not proceed to neighbors
+        #expect(mockSession.requestCount == 1)
+    }
+
+    @Test("Returns empty when search fails")
+    func returnsEmptyWhenSearchFails() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        // No responses configured — search will fail
+
+        let recommendations = await service.recommendations(forArtistNamed: "Stereolab")
+        #expect(recommendations.isEmpty)
+    }
+
+    @Test("Returns empty when search succeeds but neighbors fails")
+    func returnsEmptyWhenNeighborsFails() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = """
+        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        """.data(using: .utf8)!
+
+        // No neighbors response — will fail
+
+        let recommendations = await service.recommendations(forArtistNamed: "Stereolab")
+        #expect(recommendations.isEmpty)
+    }
+}

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceSearchTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceSearchTests.swift
@@ -1,0 +1,97 @@
+//
+//  SemanticIndexServiceSearchTests.swift
+//  SemanticIndex
+//
+//  Tests for SemanticIndexService artist search functionality.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import Caching
+@testable import SemanticIndex
+
+@Suite("SemanticIndexService Search")
+struct SemanticIndexServiceSearchTests {
+
+    @Test("Constructs correct search URL with query and limit")
+    func constructsCorrectSearchURL() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = """
+        [{"id": 1, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        """.data(using: .utf8)!
+
+        _ = await service.searchArtist(name: "Stereolab")
+
+        #expect(mockSession.requestCount == 1)
+        let url = try #require(mockSession.requestedURLs.first)
+        #expect(url.path().contains("graph/artists/search"))
+        #expect(url.absoluteString.contains("q=Stereolab"))
+        #expect(url.absoluteString.contains("limit=1"))
+    }
+
+    @Test("Decodes artist from search response")
+    func decodesArtist() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = """
+        [{"id": 42, "canonical_name": "Broadcast", "genre": "Electronic", "total_plays": 300}]
+        """.data(using: .utf8)!
+
+        let artist = await service.searchArtist(name: "Broadcast")
+
+        let result = try #require(artist)
+        #expect(result.id == 42)
+        #expect(result.canonicalName == "Broadcast")
+        #expect(result.genre == "Electronic")
+        #expect(result.totalPlays == 300)
+    }
+
+    @Test("Returns nil when search returns empty array")
+    func returnsNilForEmptyResults() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = "[]".data(using: .utf8)!
+
+        let artist = await service.searchArtist(name: "Nonexistent Artist")
+        #expect(artist == nil)
+    }
+
+    @Test("Returns nil when API errors")
+    func returnsNilOnError() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        // No response configured — will throw
+
+        let artist = await service.searchArtist(name: "Stereolab")
+        #expect(artist == nil)
+    }
+}

--- a/WXYC.xcodeproj/project.pbxproj
+++ b/WXYC.xcodeproj/project.pbxproj
@@ -37,6 +37,7 @@
 		3FE7F1333D67FB073FBB13EF /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = 01BA6F026317213ACE8EE228 /* PostHog */; };
 		524AA009A7901EA1DDC81851 /* PlayerHeaderView in Frameworks */ = {isa = PBXBuildFile; productRef = 35DC07836DEEE44F7B819265 /* PlayerHeaderView */; };
 		62C0D7BB9157E5D3D858DA97 /* Metadata in Frameworks */ = {isa = PBXBuildFile; productRef = BE7D47372C4F1F83B0F271DE /* Metadata */; };
+		640E864ECA804253A05BBCE8 /* SemanticIndex in Frameworks */ = {isa = PBXBuildFile; productRef = EF864A6DFCDF4E5F81D26B76 /* SemanticIndex */; };
 		7795E1821F6367CC00C37ED0 /* Playlist in Frameworks */ = {isa = PBXBuildFile; productRef = 0852AD2E14147E5B270AD1F1 /* Playlist */; };
 		78F01F75D235BCEE06C05F71 /* Analytics in Frameworks */ = {isa = PBXBuildFile; productRef = 9AA59EC6C2A143F5728D04F9 /* Analytics */; };
 		7FD230E5DD398FE4B7F0AE06 /* PartyHorn in Frameworks */ = {isa = PBXBuildFile; productRef = 3DF76684E122C2FAD4F26E27 /* PartyHorn */; };
@@ -140,6 +141,7 @@
 		236B51D12EFC651A0058AD01 /* SwiftUI.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SwiftUI.framework; path = /System/Library/Frameworks/SwiftUI.framework; sourceTree = "<absolute>"; };
 		23FD1F9E3836A69490D508B9 /* Artwork */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Artwork; path = Shared/Artwork; sourceTree = SOURCE_ROOT; };
 		2E2DA266F8734B81F467E9C3 /* Metadata */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Metadata; path = Shared/Metadata; sourceTree = SOURCE_ROOT; };
+		71601404AC044E9FBCDE2CD6 /* SemanticIndex */ = {isa = PBXFileReference; lastKnownFileType = folder; name = SemanticIndex; path = Shared/SemanticIndex; sourceTree = SOURCE_ROOT; };
 		408862FFDA682059B46DBE38 /* PlayerHeaderView */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PlayerHeaderView; path = Shared/PlayerHeaderView; sourceTree = SOURCE_ROOT; };
 		4FA5098D4C45B1A40664F383 /* Playback */ = {isa = PBXFileReference; lastKnownFileType = folder; name = Playback; path = Shared/Playback; sourceTree = SOURCE_ROOT; };
 		6D8ECE997571529CE8187362 /* WXYC TV.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = "WXYC TV.app"; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -334,6 +336,7 @@
 				23D418182EF2C80000WALLPA /* Wallpaper in Frameworks */,
 				23D418192EF2C8000DBGPNL /* DebugPanel in Frameworks */,
 				62C0D7BB9157E5D3D858DA97 /* Metadata in Frameworks */,
+				640E864ECA804253A05BBCE8 /* SemanticIndex in Frameworks */,
 				A7CF425E5F8EBCE498636FAB /* Artwork in Frameworks */,
 				1F511646EB98B7621319A1DA /* AppServices in Frameworks */,
 				37327445A68BBA56C392BEF7 /* WXUI in Frameworks */,
@@ -419,6 +422,7 @@
 				INTENTSPKGFILEREF000001 /* Intents */,
 				21C88FF06CCC47E090003EAD /* Logger */,
 				2E2DA266F8734B81F467E9C3 /* Metadata */,
+				71601404AC044E9FBCDE2CD6 /* SemanticIndex */,
 				1CA6C2A20CF184C75A3C62E5 /* MusicShareKit */,
 				FF0D2C45269DEE0E530C46D3 /* PartyHorn */,
 				4FA5098D4C45B1A40664F383 /* Playback */,
@@ -619,6 +623,7 @@
 				8FCE16D2F8F98E766EFCFFDF /* Caching */,
 				D1362165656CBF5DDD9E5DDA /* Playlist */,
 				BE7D47372C4F1F83B0F271DE /* Metadata */,
+				EF864A6DFCDF4E5F81D26B76 /* SemanticIndex */,
 				196F9D43ACA1827478F32D5D /* Artwork */,
 				EE16E35E8F1311399E5AD843 /* AppServices */,
 				01163D6D065337EB60F79C5B /* WXUI */,
@@ -688,6 +693,7 @@
 				23D4181B2EF2C8000DBGPNL /* XCLocalSwiftPackageReference "Shared/DebugPanel" */,
 				D23B4D7A8AFC723FA2812948 /* XCLocalSwiftPackageReference "Shared/Logger" */,
 				8556716B922ADAEAD20A238A /* XCLocalSwiftPackageReference "Shared/Metadata" */,
+				D35890F59FD44C2E95EBF09F /* XCLocalSwiftPackageReference "Shared/SemanticIndex" */,
 				9E445D20EDBF8A92397DA93F /* XCLocalSwiftPackageReference "Shared/PartyHorn" */,
 				F312D55190C505B9EE16903A /* XCLocalSwiftPackageReference "Shared/Playback" */,
 				6220DC310DFF2FC4A929FDB0 /* XCLocalSwiftPackageReference "Shared/PlayerHeaderView" */,
@@ -2407,6 +2413,10 @@
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Shared/Metadata;
 		};
+		D35890F59FD44C2E95EBF09F /* XCLocalSwiftPackageReference "Shared/SemanticIndex" */ = {
+			isa = XCLocalSwiftPackageReference;
+			relativePath = Shared/SemanticIndex;
+		};
 		9E445D20EDBF8A92397DA93F /* XCLocalSwiftPackageReference "Shared/PartyHorn" */ = {
 			isa = XCLocalSwiftPackageReference;
 			relativePath = Shared/PartyHorn;
@@ -2651,6 +2661,10 @@
 		BE7D47372C4F1F83B0F271DE /* Metadata */ = {
 			isa = XCSwiftPackageProductDependency;
 			productName = Metadata;
+		};
+		EF864A6DFCDF4E5F81D26B76 /* SemanticIndex */ = {
+			isa = XCSwiftPackageProductDependency;
+			productName = SemanticIndex;
 		};
 		C0D1E2F30405162718192AC3 /* PostHog */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/WXYC/iOS/Tests/WXYC.xctestplan
+++ b/WXYC/iOS/Tests/WXYC.xctestplan
@@ -146,6 +146,14 @@
         "identifier" : "AnalyticsTests",
         "name" : "AnalyticsTests"
       }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Shared\/SemanticIndex",
+        "identifier" : "SemanticIndexTests",
+        "name" : "SemanticIndexTests"
+      }
     }
   ],
   "version" : 1

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistDetailView.swift
@@ -1,0 +1,175 @@
+//
+//  ArtistDetailView.swift
+//  WXYC
+//
+//  Detail view for a recommended artist pushed from WXYCRecommendsSection.
+//  Fetches artist detail, preview, and bio from the semantic-index and
+//  metadata services, reusing existing UI components throughout.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Analytics
+import Metadata
+import MusicShareKit
+import SemanticIndex
+import SwiftUI
+import WXUI
+
+struct ArtistDetailView: View {
+    let artist: RecommendedArtist
+
+    @State private var detail: SemanticIndexArtistDetail?
+    @State private var preview: SemanticIndexPreview?
+    @State private var bio: String?
+    @State private var isLoading = true
+    @State private var expandedBio = false
+
+    private let semanticService = SemanticIndexService()
+    private let metadataService = PlaycutMetadataService(tokenProvider: MusicShareKit.authService)
+
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 24) {
+                artworkSection
+
+                infoSection
+
+                if let bio, !bio.isEmpty {
+                    ArtistBioSection(bio: bio, expandedBio: $expandedBio)
+                        .padding()
+                        .background(
+                            RoundedRectangle(cornerRadius: 16)
+                                .fill(.primary.opacity(0.1))
+                        )
+                }
+
+                if let detail {
+                    let links = ArtistStreamingLinks(detail: detail, preview: preview)
+                    if links.hasLinks {
+                        ArtistStreamingLinksSection(
+                            links: links,
+                            onServiceTapped: { service in
+                                StructuredPostHogAnalytics.shared.capture(StreamingLinkTapped(
+                                    service: service,
+                                    artist: artist.name,
+                                    album: ""
+                                ))
+                            }
+                        )
+                    }
+                }
+
+                if !isLoading {
+                    WXYCRecommendsSection(artistName: artist.name)
+                        .foregroundStyle(.white)
+                }
+
+                Spacer(minLength: 40)
+            }
+            .padding(.horizontal)
+        }
+        .scrollClipDisabled()
+        .scrollContentBackground(.hidden)
+        .overlaySheetScrollTracking()
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbarColorScheme(.dark, for: .navigationBar)
+        .foregroundStyle(.white)
+        .onAppear {
+            StructuredPostHogAnalytics.shared.capture(ArtistDetailViewPresented(artist: artist.name))
+        }
+        .task {
+            await loadArtistData()
+        }
+    }
+
+    // MARK: - Artwork
+
+    private var artworkSection: some View {
+        Group {
+            if let artworkURL = preview?.artworkURL {
+                AsyncImage(url: artworkURL) { phase in
+                    switch phase {
+                    case .success(let image):
+                        image
+                            .resizable()
+                            .aspectRatio(contentMode: .fit)
+                            .clipShape(.rect(cornerRadius: 12))
+                            .shadow(radius: 20, x: 0, y: 10)
+                    default:
+                        artworkPlaceholder
+                    }
+                }
+            } else {
+                artworkPlaceholder
+            }
+        }
+        .frame(maxWidth: 280, maxHeight: 280)
+        .padding(.top, 30)
+    }
+
+    private var artworkPlaceholder: some View {
+        RoundedRectangle(cornerRadius: 12)
+            .fill(.ultraThinMaterial)
+            .overlay {
+                Image(systemName: "music.note")
+                    .font(.system(size: 40))
+                    .foregroundStyle(.secondary)
+            }
+            .aspectRatio(1, contentMode: .fit)
+    }
+
+    // MARK: - Info
+
+    private var infoSection: some View {
+        VStack(spacing: 6) {
+            Text(artist.name)
+                .font(.title2)
+                .bold()
+                .multilineTextAlignment(.center)
+
+            if let genre = artist.genre {
+                GenreTagsView(tags: [genre])
+            }
+
+            if let trackName = preview?.trackName, let albumName = preview?.albumName {
+                Text("\(trackName) — \(albumName)")
+                    .font(.subheadline)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.center)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    // MARK: - Data Loading
+
+    private func loadArtistData() async {
+        async let detailTask = semanticService.artistDetail(id: artist.id)
+        async let previewTask = semanticService.preview(for: artist.id)
+
+        let (fetchedDetail, fetchedPreview) = await (detailTask, previewTask)
+
+        // Fetch bio if we got a Discogs artist ID
+        var fetchedBio: String?
+        if let discogsId = fetchedDetail?.discogsArtistId {
+            fetchedBio = await fetchArtistBio(discogsArtistId: discogsId)
+        }
+
+        await MainActor.run {
+            withAnimation(.easeInOut(duration: 0.3)) {
+                self.detail = fetchedDetail
+                self.preview = fetchedPreview
+                self.bio = fetchedBio
+                self.isLoading = false
+            }
+        }
+    }
+
+    private func fetchArtistBio(discogsArtistId: Int) async -> String? {
+        // Reuse the metadata service to fetch artist bio via the existing proxy
+        let metadata = await metadataService.fetchArtistBio(discogsArtistId: discogsArtistId)
+        return metadata
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistStreamingLinksSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistStreamingLinksSection.swift
@@ -1,0 +1,109 @@
+//
+//  ArtistStreamingLinksSection.swift
+//  WXYC
+//
+//  Streaming links section for the artist detail view. Reuses the existing
+//  LinkButtonLabel and StreamingButton patterns but adapts for artist-level
+//  links from the semantic-index rather than track-level links from metadata.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import SwiftUI
+import Metadata
+import SemanticIndex
+import WXUI
+
+struct ArtistStreamingLinksSection: View {
+    let links: ArtistStreamingLinks
+    var onServiceTapped: ((String) -> Void)?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Listen on")
+                .font(.detailSectionHeader)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            LazyVGrid(columns: [
+                GridItem(.flexible()),
+                GridItem(.flexible())
+            ], spacing: 12) {
+                if let url = links.appleMusicURL {
+                    ArtistLinkButton(
+                        service: .appleMusic,
+                        url: url,
+                        onTap: onServiceTapped
+                    )
+                }
+
+                if let url = links.spotifyURL {
+                    ArtistLinkButton(
+                        service: .spotify,
+                        url: url,
+                        onTap: onServiceTapped
+                    )
+                }
+
+                if let url = links.bandcampURL {
+                    ArtistLinkButton(
+                        service: .bandcamp,
+                        url: url,
+                        onTap: onServiceTapped
+                    )
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.primary.opacity(0.1))
+        )
+    }
+}
+
+// MARK: - Artist Link Button
+
+/// A streaming link button adapted for the artist detail context.
+/// Reuses the existing `LinkButtonLabel` layout but always has a URL
+/// (only shown when the link is available).
+private struct ArtistLinkButton: View {
+    let service: StreamingService
+    let url: URL
+    var onTap: ((String) -> Void)?
+
+    @State private var showingSafari = false
+
+    private var icon: LinkButtonLabel.Icon {
+        if service.hasCustomIcon {
+            .custom(name: service.iconName, bundle: .playlist)
+        } else {
+            .system(name: service.systemIcon)
+        }
+    }
+
+    var body: some View {
+        Button {
+            onTap?(service.name)
+            if service.opensInBrowser {
+                showingSafari = true
+            } else {
+                UIApplication.shared.open(url)
+            }
+        } label: {
+            LinkButtonLabel(
+                icon: icon,
+                title: service.name,
+                font: .caption,
+                foregroundShapeStyle: AnyShapeStyle(.white),
+                backgroundFill: AnyShapeStyle(service.color),
+                alignment: .leading,
+                spacing: 8
+            )
+        }
+        .sheet(isPresented: $showingSafari) {
+            SafariView(url: url)
+        }
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/PlaycutDetailView.swift
@@ -9,6 +9,7 @@
 import Analytics
 import AppIntents
 import AppServices
+import Artwork
 import Metadata
 import MusicShareKit
 import Playlist
@@ -33,6 +34,7 @@ struct PlaycutDetailView: View {
     @State private var hideHeaderArtwork = false
     @Namespace private var artworkNamespace
     
+    @Environment(\.artworkService) private var artworkService
     @Environment(\.colorScheme) var colorScheme
     @Environment(\.reviewRequestService) var reviewRequestService
 
@@ -102,6 +104,12 @@ struct PlaycutDetailView: View {
                     .foregroundStyle(.white)
                 }
                 
+                // WXYC Recommends
+                if !isLoadingMetadata {
+                    WXYCRecommendsSection(artistName: playcut.artistName)
+                        .foregroundStyle(.white)
+                }
+
                 Spacer(minLength: 40)
             }
             .padding(.horizontal)

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/RecommendedArtist.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/RecommendedArtist.swift
@@ -1,0 +1,23 @@
+//
+//  RecommendedArtist.swift
+//  WXYC
+//
+//  Navigation value for pushing to an ArtistDetailView from a WXYC
+//  Recommends section. Carries the minimal data needed to display
+//  the artist detail screen.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Foundation
+
+/// A recommended artist used as a navigation destination value.
+///
+/// Contains the semantic-index artist ID, canonical name, and genre.
+/// Conforms to `Hashable` for use with `navigationDestination(for:)`.
+struct RecommendedArtist: Hashable {
+    let id: Int
+    let name: String
+    let genre: String?
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/RecommendedArtistRow.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/RecommendedArtistRow.swift
@@ -1,0 +1,61 @@
+//
+//  RecommendedArtistRow.swift
+//  WXYC
+//
+//  A single row in the WXYC Recommends section, displaying a recommended
+//  artist's name and genre as a NavigationLink.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import SwiftUI
+import SemanticIndex
+
+struct RecommendedArtistRow: View {
+    let neighbor: SemanticIndexNeighbor
+
+    private var destination: RecommendedArtist {
+        RecommendedArtist(
+            id: neighbor.artist.id,
+            name: neighbor.artist.canonicalName,
+            genre: neighbor.artist.genre
+        )
+    }
+
+    var body: some View {
+        NavigationLink(value: destination) {
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text(neighbor.artist.canonicalName)
+                        .font(.body)
+                        .fontWeight(.medium)
+                        .lineLimit(1)
+
+                    if let genre = neighbor.artist.genre {
+                        Text(genre)
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                    }
+                }
+
+                Spacer()
+
+                if let totalPlays = neighbor.artist.totalPlays {
+                    Text(totalPlays, format: .number)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                    Text("plays")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+
+                Image(systemName: "chevron.right")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/WXYCRecommendsSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/WXYCRecommendsSection.swift
@@ -1,0 +1,78 @@
+//
+//  WXYCRecommendsSection.swift
+//  WXYC
+//
+//  Displays up to 3 DJ-validated artist recommendations from the WXYC
+//  semantic-index graph. Renders nothing when the artist is not in the
+//  graph or the API is unavailable.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Analytics
+import SwiftUI
+import SemanticIndex
+import WXUI
+
+struct WXYCRecommendsSection: View {
+    let artistName: String
+
+    @State private var neighbors: [SemanticIndexNeighbor] = []
+    @State private var isLoading = true
+
+    private let service = SemanticIndexService()
+
+    var body: some View {
+        if isLoading {
+            loadingView
+        } else if !neighbors.isEmpty {
+            contentView
+        }
+    }
+
+    private var loadingView: some View {
+        ProgressView()
+            .tint(.white)
+            .frame(maxWidth: .infinity)
+            .frame(height: 44)
+            .task {
+                let results = await service.recommendations(forArtistNamed: artistName)
+                await MainActor.run {
+                    withAnimation(.easeInOut(duration: 0.3)) {
+                        self.neighbors = results
+                        self.isLoading = false
+                    }
+                }
+            }
+    }
+
+    private var contentView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("WXYC Recommends")
+                .font(.detailSectionHeader)
+                .foregroundStyle(.primary)
+                .frame(maxWidth: .infinity, alignment: .leading)
+
+            ForEach(neighbors) { neighbor in
+                RecommendedArtistRow(neighbor: neighbor)
+                    .simultaneousGesture(TapGesture().onEnded {
+                        StructuredPostHogAnalytics.shared.capture(RecommendedArtistTapped(
+                            sourceArtist: artistName,
+                            recommendedArtist: neighbor.artist.canonicalName
+                        ))
+                    })
+
+                if neighbor.id != neighbors.last?.id {
+                    Divider()
+                        .overlay(.white.opacity(0.2))
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 16)
+                .fill(.primary.opacity(0.1))
+        )
+    }
+}

--- a/WXYC/iOS/Views/Root/RootTabView.swift
+++ b/WXYC/iOS/Views/Root/RootTabView.swift
@@ -37,8 +37,14 @@ struct RootTabView: View {
             get: { selectedPlaycut != nil },
             set: { if !$0 { selectedPlaycut = nil } }
         )) {
-            if let selection = selectedPlaycut {
-                PlaycutDetailView(playcut: selection.playcut, artwork: selection.artwork)
+            NavigationStack {
+                if let selection = selectedPlaycut {
+                    PlaycutDetailView(playcut: selection.playcut, artwork: selection.artwork)
+                        .toolbar(.hidden, for: .navigationBar)
+                        .navigationDestination(for: RecommendedArtist.self) { artist in
+                            ArtistDetailView(artist: artist)
+                        }
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

- New `SemanticIndex` Swift package with API client for `explore.wxyc.org`, providing artist search, neighbor lookups, and detail/preview fetching with multi-level caching (22 tests)
- "WXYC Recommends" section on PlaycutDetailView showing top 3 DJ-validated transitions with recursive artist exploration via NavigationStack
- ArtistDetailView with artwork, bio (reuses existing ArtistBioSection + metadata proxy), streaming links (reuses LinkButtonLabel/StreamingButton), and recursive recommendations
- Analytics events: `RecommendedArtistTapped`, `ArtistDetailViewPresented`

Closes #216

## Test plan

- [ ] Open a playcut detail → scroll past bio → verify "WXYC Recommends" appears with up to 3 artists
- [ ] Tap a recommended artist → verify ArtistDetailView pushes with back navigation
- [ ] Verify streaming links (Apple Music, Spotify, Bandcamp) open correct URLs
- [ ] Verify recursive: ArtistDetailView also shows "WXYC Recommends"
- [ ] Test offline/unavailable API: section gracefully disappears
- [ ] Verify swipe-back gesture works in overlay sheet