### PR TITLE
Clean up SemanticIndex from review feedback

### DIFF
--- a/Shared/Caching/Sources/Caching/CacheCoordinator.swift
+++ b/Shared/Caching/Sources/Caching/CacheCoordinator.swift
@@ -80,6 +80,12 @@ public final actor CacheCoordinator {
     /// and streaming service links.
     public static let Metadata = CacheCoordinator(cache: DiskCache())
 
+    /// Cache coordinator for semantic-index API responses.
+    ///
+    /// Stores artist search results, neighbor transitions, artist detail,
+    /// and preview data from the `explore.wxyc.org` graph API.
+    public static let SemanticIndex = CacheCoordinator(cache: DiskCache(subdirectory: "semantic-index"))
+
     // MARK: - Error Types
 
     /// Errors that can occur during cache operations.

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexPreview.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexPreview.swift
@@ -16,45 +16,55 @@ import Foundation
 /// Provides artwork URLs, track names, and Apple Music album deep links
 /// sourced from the iTunes Search API cache in the Transition Player backend.
 public struct SemanticIndexPreview: Codable, Sendable, Hashable {
-    public let previewUrl: String?
+    public let previewURL: URL?
     public let trackName: String?
     public let artistName: String?
-    public let artworkUrl: String?
+    public let artworkURL: URL?
     public let albumName: String?
-    public let albumUrl: String?
+    public let albumURL: URL?
 
     public init(
-        previewUrl: String? = nil,
+        previewURL: URL? = nil,
         trackName: String? = nil,
         artistName: String? = nil,
-        artworkUrl: String? = nil,
+        artworkURL: URL? = nil,
         albumName: String? = nil,
-        albumUrl: String? = nil
+        albumURL: URL? = nil
     ) {
-        self.previewUrl = previewUrl
+        self.previewURL = previewURL
         self.trackName = trackName
         self.artistName = artistName
-        self.artworkUrl = artworkUrl
+        self.artworkURL = artworkURL
         self.albumName = albumName
-        self.albumUrl = albumUrl
+        self.albumURL = albumURL
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.trackName = try container.decodeIfPresent(String.self, forKey: .trackName)
+        self.artistName = try container.decodeIfPresent(String.self, forKey: .artistName)
+        self.albumName = try container.decodeIfPresent(String.self, forKey: .albumName)
+        self.previewURL = try container.decodeIfPresent(String.self, forKey: .previewURL).flatMap { URL(string: $0) }
+        self.artworkURL = try container.decodeIfPresent(String.self, forKey: .artworkURL).flatMap { URL(string: $0) }
+        self.albumURL = try container.decodeIfPresent(String.self, forKey: .albumURL).flatMap { URL(string: $0) }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(trackName, forKey: .trackName)
+        try container.encodeIfPresent(artistName, forKey: .artistName)
+        try container.encodeIfPresent(albumName, forKey: .albumName)
+        try container.encodeIfPresent(previewURL?.absoluteString, forKey: .previewURL)
+        try container.encodeIfPresent(artworkURL?.absoluteString, forKey: .artworkURL)
+        try container.encodeIfPresent(albumURL?.absoluteString, forKey: .albumURL)
     }
 
     private enum CodingKeys: String, CodingKey {
-        case previewUrl = "preview_url"
+        case previewURL = "preview_url"
         case trackName = "track_name"
         case artistName = "artist_name"
-        case artworkUrl = "artwork_url"
+        case artworkURL = "artwork_url"
         case albumName = "album_name"
-        case albumUrl = "album_url"
-    }
-
-    /// The artwork URL as a typed `URL`, or `nil` if the string is missing or invalid.
-    public var artworkURL: URL? {
-        artworkUrl.flatMap { URL(string: $0) }
-    }
-
-    /// The Apple Music album URL as a typed `URL`, or `nil` if the string is missing or invalid.
-    public var albumURL: URL? {
-        albumUrl.flatMap { URL(string: $0) }
+        case albumURL = "album_url"
     }
 }

--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
@@ -27,6 +27,9 @@ import struct Logger.Category
 ///
 /// All responses are cached via ``CacheCoordinator`` to reduce redundant API calls.
 public actor SemanticIndexService {
+    /// Shared instance for use by views. Uses the default base URL, cache, and error reporter.
+    public static let shared = SemanticIndexService()
+
     private let baseURL: URL
     private let session: WebSession
     private let cache: CacheCoordinator
@@ -38,14 +41,14 @@ public actor SemanticIndexService {
     ) {
         self.baseURL = baseURL
         self.session = URLSession.shared
-        self.cache = .Metadata
+        self.cache = .SemanticIndex
         self.errorReporter = errorReporter
     }
 
     init(
         baseURL: URL = URL(string: "https://explore.wxyc.org")!,
         session: WebSession,
-        cache: CacheCoordinator = .Metadata,
+        cache: CacheCoordinator = .SemanticIndex,
         errorReporter: any ErrorReporter = ErrorReporting.shared
     ) {
         self.baseURL = baseURL

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/ArtistStreamingLinksTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/ArtistStreamingLinksTests.swift
@@ -45,7 +45,7 @@ struct ArtistStreamingLinksTests {
             appleMusicArtistId: "artist456"
         )
         let preview = SemanticIndexPreview(
-            albumUrl: "https://music.apple.com/album/tnt/123456"
+            albumURL: URL(string: "https://music.apple.com/album/tnt/123456")
         )
         let links = ArtistStreamingLinks(detail: detail, preview: preview)
         #expect(links.appleMusicURL == URL(string: "https://music.apple.com/album/tnt/123456"))

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceCachingTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceCachingTests.swift
@@ -1,0 +1,114 @@
+//
+//  SemanticIndexServiceCachingTests.swift
+//  SemanticIndex
+//
+//  Tests verifying that SemanticIndexService caches API responses and
+//  avoids redundant network calls on subsequent fetches.
+//
+//  Created by Jake Bromberg on 04/22/26.
+//  Copyright © 2026 WXYC. All rights reserved.
+//
+
+import Testing
+import Foundation
+import Core
+@testable import Caching
+@testable import SemanticIndex
+
+@Suite("SemanticIndexService Caching")
+struct SemanticIndexServiceCachingTests {
+
+    @Test("Second search returns cached result without API call")
+    func searchCachesResult() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/search"] = """
+        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        """.data(using: .utf8)!
+
+        let first = await service.searchArtist(name: "Stereolab")
+        let firstRequestCount = mockSession.requestCount
+
+        let second = await service.searchArtist(name: "Stereolab")
+
+        #expect(first?.id == 42)
+        #expect(second?.id == 42)
+        #expect(mockSession.requestCount == firstRequestCount, "Second search should use cache")
+    }
+
+    @Test("Second neighbors call returns cached result without API call")
+    func neighborsCachesResult() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42/neighbors"] = """
+        [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]
+        """.data(using: .utf8)!
+
+        let first = await service.neighbors(for: 42)
+        let firstRequestCount = mockSession.requestCount
+
+        let second = await service.neighbors(for: 42)
+
+        #expect(first.count == 1)
+        #expect(second.count == 1)
+        #expect(mockSession.requestCount == firstRequestCount, "Second neighbors call should use cache")
+    }
+
+    @Test("Second artist detail call returns cached result without API call")
+    func artistDetailCachesResult() async throws {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42"] = """
+        {"id": 42, "canonical_name": "Broadcast", "genre": "Electronic", "total_plays": 300}
+        """.data(using: .utf8)!
+
+        let first = await service.artistDetail(id: 42)
+        let firstRequestCount = mockSession.requestCount
+
+        let second = await service.artistDetail(id: 42)
+
+        #expect(first?.canonicalName == "Broadcast")
+        #expect(second?.canonicalName == "Broadcast")
+        #expect(mockSession.requestCount == firstRequestCount, "Second detail call should use cache")
+    }
+
+    @Test("Different heat values use separate cache entries")
+    func differentHeatValuesNotShared() async {
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        mockSession.responses["graph/artists/42/neighbors"] = """
+        [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]
+        """.data(using: .utf8)!
+
+        _ = await service.neighbors(for: 42, heat: 0.0)
+        let afterCool = mockSession.requestCount
+
+        _ = await service.neighbors(for: 42, heat: 0.5)
+
+        #expect(mockSession.requestCount == afterCool + 1, "Different heat should bypass cache")
+    }
+}

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistDetailView.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/ArtistDetailView.swift
@@ -26,7 +26,7 @@ struct ArtistDetailView: View {
     @State private var isLoading = true
     @State private var expandedBio = false
 
-    private let semanticService = SemanticIndexService()
+    private let semanticService = SemanticIndexService.shared
     private let metadataService = PlaycutMetadataService(tokenProvider: MusicShareKit.authService)
 
     var body: some View {
@@ -37,7 +37,7 @@ struct ArtistDetailView: View {
                 infoSection
 
                 if let bio, !bio.isEmpty {
-                    ArtistBioSection(bio: bio, expandedBio: $expandedBio)
+                    ArtistBioSection(bio: bio, bioTokens: nil, expandedBio: $expandedBio)
                         .padding()
                         .background(
                             RoundedRectangle(cornerRadius: 16)

--- a/WXYC/iOS/Views/Playlist/Playcut Detail/WXYCRecommendsSection.swift
+++ b/WXYC/iOS/Views/Playlist/Playcut Detail/WXYCRecommendsSection.swift
@@ -21,7 +21,7 @@ struct WXYCRecommendsSection: View {
     @State private var neighbors: [SemanticIndexNeighbor] = []
     @State private var isLoading = true
 
-    private let service = SemanticIndexService()
+    private let service = SemanticIndexService.shared
 
     var body: some View {
         if isLoading {


### PR DESCRIPTION
## Summary

- Store `URL?` properties directly in `SemanticIndexPreview` instead of `String?` with computed `URL?` wrappers, matching the `AlbumMetadata`/`ArtistMetadata` pattern
- Add dedicated `CacheCoordinator.SemanticIndex` with its own `DiskCache` subdirectory instead of sharing `.Metadata`
- Use `SemanticIndexService.shared` singleton instead of creating a new actor per view instance in `WXYCRecommendsSection` and `ArtistDetailView`
- Add `SemanticIndexServiceCachingTests` (4 tests) verifying cache hits on repeated calls and separate cache entries for different heat values

Follow-up to #217.

## Test plan

- [x] All 26 SemanticIndex tests pass (22 existing + 4 new caching tests)
- [x] Full project builds for simulator