### PR TITLE
Enable JWT E2E test after backend deploy

### DIFF
--- a/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthNetworkClientE2ETests.swift
+++ b/Shared/MusicShareKit/Tests/MusicShareKitTests/AuthNetworkClientE2ETests.swift
@@ -85,8 +85,7 @@ struct AuthNetworkClientE2ETests {
         #expect(payload.expiresAt > Date())
     }
 
-    @Test("JWT from exchange authenticates against /config/secrets",
-          .disabled("Requires WXYC/Backend-Service#376 (JWT-only verification)"))
+    @Test("JWT from exchange authenticates against /config/secrets")
     func jwtAuthenticatesAgainstSecrets() async throws {
         let client = makeClient()
         let session = try await client.signInAnonymously(baseURL: baseURL)


### PR DESCRIPTION
## Summary

- Re-enable `jwtAuthenticatesAgainstSecrets` E2E test that was disabled pending WXYC/Backend-Service#376
- Verified passing against live `api.wxyc.org` — JWT from `/auth/token` now authenticates against `/config/secrets`

Follow-up to #213.