### PR TITLE
Decode semantic-index search and neighbors response wrappers

### DIFF
--- a/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
+++ b/Shared/SemanticIndex/Sources/SemanticIndex/SemanticIndexService.swift
@@ -77,13 +77,16 @@ public actor SemanticIndexService {
                 cache: cache,
                 lifespan: .sevenDays,
                 fetch: {
-                    try await fetchJSON(
+                    // The /graph/artists/search endpoint returns
+                    // { "results": [...] } — decode the wrapper and unwrap.
+                    let response: SearchResponse = try await fetchJSON(
                         path: "graph/artists/search",
                         queryItems: [
                             URLQueryItem(name: "q", value: name),
                             URLQueryItem(name: "limit", value: "1"),
                         ]
                     )
+                    return response.results
                 }
             )
         }
@@ -112,7 +115,10 @@ public actor SemanticIndexService {
                 cache: cache,
                 lifespan: .sevenDays,
                 fetch: {
-                    try await fetchJSON(
+                    // The /graph/artists/{id}/neighbors endpoint returns
+                    // { "artist", "edge_type", "neighbors": [...] } —
+                    // decode the wrapper and unwrap to the neighbor list.
+                    let response: NeighborsResponse = try await fetchJSON(
                         path: "graph/artists/\(artistId)/neighbors",
                         queryItems: [
                             URLQueryItem(name: "type", value: "djTransition"),
@@ -120,6 +126,7 @@ public actor SemanticIndexService {
                             URLQueryItem(name: "limit", value: String(limit)),
                         ]
                     )
+                    return response.neighbors
                 },
                 fallback: { [] }
             )
@@ -216,4 +223,21 @@ extension SemanticIndexService {
     enum SemanticIndexError: Error {
         case invalidURL
     }
+}
+
+// MARK: - Response wrappers
+
+/// Wrapper for the `/graph/artists/search` endpoint, which returns
+/// `{ "results": [...] }`. iOS only consumes the inner array — these types
+/// exist to thread the decode through `JSONDecoder` without leaking the
+/// envelope into callers.
+private struct SearchResponse: Codable, Sendable {
+    let results: [SemanticIndexArtist]
+}
+
+/// Wrapper for the `/graph/artists/{id}/neighbors` endpoint, which returns
+/// `{ "artist", "edge_type", "neighbors": [...] }`. iOS only consumes
+/// `neighbors`; the `artist` and `edge_type` envelope fields are dropped.
+private struct NeighborsResponse: Codable, Sendable {
+    let neighbors: [SemanticIndexNeighbor]
 }

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceCachingTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceCachingTests.swift
@@ -29,7 +29,7 @@ struct SemanticIndexServiceCachingTests {
         )
 
         mockSession.responses["graph/artists/search"] = """
-        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        {"results": [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]}
         """.data(using: .utf8)!
 
         let first = await service.searchArtist(name: "Stereolab")
@@ -53,7 +53,7 @@ struct SemanticIndexServiceCachingTests {
         )
 
         mockSession.responses["graph/artists/42/neighbors"] = """
-        [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]
+        {"artist": {"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}, "edge_type": "djTransition", "neighbors": [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]}
         """.data(using: .utf8)!
 
         let first = await service.neighbors(for: 42)
@@ -101,7 +101,7 @@ struct SemanticIndexServiceCachingTests {
         )
 
         mockSession.responses["graph/artists/42/neighbors"] = """
-        [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]
+        {"artist": {"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}, "edge_type": "djTransition", "neighbors": [{"artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200}, "weight": 0.85}]}
         """.data(using: .utf8)!
 
         _ = await service.neighbors(for: 42, heat: 0.0)

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceNeighborsTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceNeighborsTests.swift
@@ -27,7 +27,7 @@ struct SemanticIndexServiceNeighborsTests {
             cache: cache
         )
 
-        mockSession.responses["graph/artists/42/neighbors"] = "[]".data(using: .utf8)!
+        mockSession.responses["graph/artists/42/neighbors"] = #"{"artist": {"id": 42, "canonical_name": "Stereolab"}, "edge_type": "djTransition", "neighbors": []}"#.data(using: .utf8)!
 
         _ = await service.neighbors(for: 42, heat: 0.0, limit: 3)
 
@@ -50,18 +50,22 @@ struct SemanticIndexServiceNeighborsTests {
         )
 
         mockSession.responses["graph/artists/42/neighbors"] = """
-        [
-            {
-                "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
-                "weight": 0.85,
-                "detail": {"raw_count": 15, "pmi": 2.3}
-            },
-            {
-                "artist": {"id": 20, "canonical_name": "Laetitia Sadier", "genre": "Rock", "total_plays": 150},
-                "weight": 0.72,
-                "detail": {"raw_count": 10, "pmi": 1.8}
-            }
-        ]
+        {
+            "artist": {"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500},
+            "edge_type": "djTransition",
+            "neighbors": [
+                {
+                    "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
+                    "weight": 0.85,
+                    "detail": {"raw_count": 15, "pmi": 2.3}
+                },
+                {
+                    "artist": {"id": 20, "canonical_name": "Laetitia Sadier", "genre": "Rock", "total_plays": 150},
+                    "weight": 0.72,
+                    "detail": {"raw_count": 10, "pmi": 1.8}
+                }
+            ]
+        }
         """.data(using: .utf8)!
 
         let neighbors = await service.neighbors(for: 42)
@@ -86,6 +90,30 @@ struct SemanticIndexServiceNeighborsTests {
         )
 
         let neighbors = await service.neighbors(for: 42)
+        #expect(neighbors.isEmpty)
+    }
+
+    @Test("Regression: decodes the production neighbors response shape (2026-04-30 incident)")
+    func decodesProductionResponseShape() async throws {
+        // Same root cause as the search regression: the server has always
+        // returned a wrapped object ({"artist", "edge_type", "neighbors"});
+        // iOS was decoding a bare array of neighbors. This test pins iOS to
+        // the real server contract using a verbatim production response.
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        // Verbatim production response body captured 2026-04-30 from
+        // https://explore.wxyc.org/graph/artists/97426/neighbors?type=djTransition&heat=0.0&limit=3
+        mockSession.responses["graph/artists/97426/neighbors"] = #"""
+        {"artist":{"id":97426,"canonical_name":"the paradise bangkok molam international band","genre":null,"total_plays":58,"community_id":null,"pagerank":null},"edge_type":"djTransition","neighbors":[]}
+        """#.data(using: .utf8)!
+
+        let neighbors = await service.neighbors(for: 97426, heat: 0.0, limit: 3)
         #expect(neighbors.isEmpty)
     }
 }

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceRecommendationsTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceRecommendationsTests.swift
@@ -28,17 +28,21 @@ struct SemanticIndexServiceRecommendationsTests {
         )
 
         mockSession.responses["graph/artists/search"] = """
-        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        {"results": [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]}
         """.data(using: .utf8)!
 
         mockSession.responses["graph/artists/42/neighbors"] = """
-        [
-            {
-                "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
-                "weight": 0.85,
-                "detail": {"raw_count": 15, "pmi": 2.3}
-            }
-        ]
+        {
+            "artist": {"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500},
+            "edge_type": "djTransition",
+            "neighbors": [
+                {
+                    "artist": {"id": 10, "canonical_name": "Tortoise", "genre": "Rock", "total_plays": 200},
+                    "weight": 0.85,
+                    "detail": {"raw_count": 15, "pmi": 2.3}
+                }
+            ]
+        }
         """.data(using: .utf8)!
 
         let recommendations = await service.recommendations(forArtistNamed: "Stereolab")
@@ -58,7 +62,7 @@ struct SemanticIndexServiceRecommendationsTests {
             cache: cache
         )
 
-        mockSession.responses["graph/artists/search"] = "[]".data(using: .utf8)!
+        mockSession.responses["graph/artists/search"] = #"{"results": []}"#.data(using: .utf8)!
 
         let recommendations = await service.recommendations(forArtistNamed: "Unknown")
 
@@ -94,7 +98,7 @@ struct SemanticIndexServiceRecommendationsTests {
         )
 
         mockSession.responses["graph/artists/search"] = """
-        [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        {"results": [{"id": 42, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]}
         """.data(using: .utf8)!
 
         // No neighbors response — will fail

--- a/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceSearchTests.swift
+++ b/Shared/SemanticIndex/Tests/SemanticIndexTests/SemanticIndexServiceSearchTests.swift
@@ -28,7 +28,7 @@ struct SemanticIndexServiceSearchTests {
         )
 
         mockSession.responses["graph/artists/search"] = """
-        [{"id": 1, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]
+        {"results": [{"id": 1, "canonical_name": "Stereolab", "genre": "Rock", "total_plays": 500}]}
         """.data(using: .utf8)!
 
         _ = await service.searchArtist(name: "Stereolab")
@@ -51,7 +51,7 @@ struct SemanticIndexServiceSearchTests {
         )
 
         mockSession.responses["graph/artists/search"] = """
-        [{"id": 42, "canonical_name": "Broadcast", "genre": "Electronic", "total_plays": 300}]
+        {"results": [{"id": 42, "canonical_name": "Broadcast", "genre": "Electronic", "total_plays": 300}]}
         """.data(using: .utf8)!
 
         let artist = await service.searchArtist(name: "Broadcast")
@@ -73,7 +73,7 @@ struct SemanticIndexServiceSearchTests {
             cache: cache
         )
 
-        mockSession.responses["graph/artists/search"] = "[]".data(using: .utf8)!
+        mockSession.responses["graph/artists/search"] = #"{"results": []}"#.data(using: .utf8)!
 
         let artist = await service.searchArtist(name: "Nonexistent Artist")
         #expect(artist == nil)
@@ -93,5 +93,36 @@ struct SemanticIndexServiceSearchTests {
 
         let artist = await service.searchArtist(name: "Stereolab")
         #expect(artist == nil)
+    }
+
+    @Test("Regression: decodes the production response shape (2026-04-30 incident)")
+    func decodesProductionResponseShape() async throws {
+        // 2026-04-30 incident: iOS metadata fetch failed for "The Paradise
+        // Bangkok Molam International Band" with typeMismatch(Array<Any>,
+        // "Expected to decode Array<Any> but found a dictionary instead").
+        // The semantic-index API has always returned a wrapped
+        // {"results": [...]} object — iOS was decoding a bare array. The mocks
+        // used bare arrays too, so the test suite never caught the drift.
+        // This test pins the iOS decoder to the real server contract.
+        let mockSession = MockWebSession()
+        let cache = CacheCoordinator(cache: MockCache())
+        let service = SemanticIndexService(
+            baseURL: URL(string: "https://explore.wxyc.org")!,
+            session: mockSession,
+            cache: cache
+        )
+
+        // Verbatim production response body captured 2026-04-30 from
+        // https://explore.wxyc.org/graph/artists/search?q=The+Paradise+Bangkok+Molam+International+Band&limit=1
+        mockSession.responses["graph/artists/search"] = #"""
+        {"results":[{"id":97426,"canonical_name":"the paradise bangkok molam international band","genre":null,"total_plays":58,"community_id":null,"pagerank":null}]}
+        """#.data(using: .utf8)!
+
+        let artist = await service.searchArtist(name: "The Paradise Bangkok Molam International Band")
+
+        let result = try #require(artist)
+        #expect(result.id == 97426)
+        #expect(result.canonicalName == "the paradise bangkok molam international band")
+        #expect(result.totalPlays == 58)
     }
 }


### PR DESCRIPTION
## Summary
- `/graph/artists/search` returns `{"results": [...]}`; `/graph/artists/{id}/neighbors` returns `{"artist", "edge_type", "neighbors": [...]}`. iOS was decoding both as bare arrays, breaking metadata fetch in production.
- Add private `SearchResponse` / `NeighborsResponse` Codable wrappers, update the two affected fetch closures to decode + unwrap. Public API unchanged.
- Update all SemanticIndex test mocks to use the wrapped shape production returns; add regression tests using verbatim production response bodies captured 2026-04-30.

Closes #228

## Test plan
- [x] `swift test` from `Shared/SemanticIndex/`: 28/28 pass
- [x] Confirmed the same suite RED before the fix (4 search/neighbors-related tests rejected with typeMismatch)
- [ ] Build the WXYC scheme on the simulator and verify the searchArtist log lines no longer report typeMismatch
- [ ] Confirm metadata loads in the app after install